### PR TITLE
[ISSUE-42] Sub task 1 - treat url

### DIFF
--- a/src/util/treat-url.ts
+++ b/src/util/treat-url.ts
@@ -1,0 +1,83 @@
+/**
+ * Replaces any placeholders with correct values and executes any expression and replaces the expression with the execution result
+ * @param {String} url a url which can contain placeholders as well as expressions. 
+ * For eg: http(s)://domain/${GROUP}/${PROJECT_NAME}/${BRANCH}/whateverfile%{new Number(3).toString()}.txt
+ * @param group [OPTIONAL] Value for ${GROUP} placeholder. Overrides the default value
+ * @param name [OPTIONAL] Value for ${PROJECT_NAME} placeholder. Overrides the default value
+ * @param branch [OPTIONAL] Value for ${BRANCH} placeholder. Overrides the default value
+ * @returns {string} url with no placeholders and expressions
+ */
+export function treatUrl(
+  url: string,
+  group?: string,
+  name?: string,
+  branch?: string
+): string {
+  return replaceExpressions(replacePlaceholders(url, group, name, branch));
+}
+
+/**
+ * Generates placeholders values required to replace any place holders in the definition file url
+ * @param url url which contains the placeholders. For eg: https://github.com/${GROUP}/${NAME:build-chain}
+ * @param group [OPTIONAL] Value for ${GROUP} placeholder. Overrides the default value
+ * @param name [OPTIONAL] Value for ${PROJECT_NAME} placeholder. Overrides the default value
+ * @param branch [OPTIONAL] Value for ${BRANCH} placeholder. Overrides the default value
+ * @returns {string} url with no placeholders
+ */
+function replacePlaceholders(
+  url: string,
+  group?: string,
+  name?: string,
+  branch?: string
+): string {
+  let result = url;
+
+  // all url place holders are of the form ${KEY:DEFAULT} where :DEFAULT is optional
+  const placeholderRegex = /\${([^{}:]+)(:([^{}]*))?}/g;
+  const matches = [...url.matchAll(placeholderRegex)];
+  matches.forEach(match => {
+    const key = match[1];
+    // if default value is not specified then try to use env variable
+    let value = match[3] ?? process.env[key] ?? "";
+    if (key === "GROUP" && group) {
+      value = group;
+    } else if (key === "PROJECT_NAME" && name) {
+      value = name;
+    } else if (key === "BRANCH" && branch) {
+      value = branch;
+    }
+
+    result = result.replace(
+      new RegExp(`\\$\\{${key}(:([^{}]*))?}`, "gi"),
+      value
+    );
+  });
+  return result;
+}
+
+/**
+ * Replacement of eval since eval is unsafe.
+ * Refer: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval#never_use_eval!
+ * @param expression
+ * @returns
+ */
+function safeExecute(expression: string): unknown {
+  return Function(`"use strict";return (${expression})`)();
+}
+
+/**
+ * Treats the url containing a expression between `%{` and `}` (without quotes)
+ * Any string contained in `%{` and `}` is executed as javascript code. The result it produces, replaces the expression in the url
+ * @param url with expressions
+ * @returns {string} url with no expressions
+ */
+function replaceExpressions(url: string): string {
+  let result = url;
+  const expressionRegex = /%{([^%]+)}/g;
+  const matches = [...url.matchAll(expressionRegex)];
+  matches.forEach(match => {
+    // TODO: add logging
+    result = result.replace(`%{${match[1]}}`, safeExecute(match[1]) as string);
+  });
+  return result;
+}

--- a/src/util/treat-url.ts
+++ b/src/util/treat-url.ts
@@ -76,7 +76,6 @@ function replaceExpressions(url: string): string {
   const expressionRegex = /%{([^%]+)}/g;
   const matches = [...url.matchAll(expressionRegex)];
   matches.forEach(match => {
-    // TODO: add logging
     result = result.replace(`%{${match[1]}}`, safeExecute(match[1]) as string);
   });
   return result;

--- a/test/util/treat-url.test.ts
+++ b/test/util/treat-url.test.ts
@@ -1,0 +1,68 @@
+import { treatUrl } from "@bc-cr/util/treat-url";
+
+describe("replace placeholders", () => {
+  test("default value defined in the url", () => {
+    const url =
+      "https://abc/${GROUP:group}/${PROJECT_NAME:project}/${BRANCH:main}/${TEST:test}";
+    const treatedUrl = "https://abc/group/project/main/test";
+    expect(treatUrl(url)).toBe(treatedUrl);
+  });
+
+  test("default value defined in the env", () => {
+    const url = "https://abc/${GROUP}/${PROJECT_NAME}/${BRANCH}/${TEST}";
+
+    process.env = {
+      ...process.env,
+      GROUP: "group",
+      PROJECT_NAME: "project",
+      BRANCH: "main",
+      TEST: "test",
+    };
+
+    const treatedUrl = "https://abc/group/project/main/test";
+    expect(treatUrl(url)).toBe(treatedUrl);
+
+    delete process.env["GROUP"];
+    delete process.env["PROJECT_NAME"];
+    delete process.env["BRANCH"];
+    delete process.env["TEST"];
+  });
+
+  test("no default value", () => {
+    const url = "https://abc/${GROUP}/${PROJECT_NAME}/${BRANCH}/${TEST}";
+    const treatedUrl = "https://abc/group/project/main/";
+    expect(treatUrl(url, "group", "project", "main")).toBe(treatedUrl);
+  });
+
+  test("no placeholders", () => {
+    const url = "https://abc/def";
+    expect(treatUrl(url, "group", "project", "main")).toBe(url);
+  });
+});
+
+describe("replace expressions", () => {
+  test("expression executed successfully", () => {
+    const url = "https://abc/testfile%{new Number(3).toString()}.txt";
+    const treatedUrl = "https://abc/testfile3.txt";
+    expect(treatUrl(url)).toBe(treatedUrl);
+  });
+
+  test("expression execution failed", () => {
+    const url = "https://abc/testfile%{new Integer(3).toString()}.txt";
+    expect(() => treatUrl(url)).toThrowError();
+  });
+
+  test("no expression", () => {
+    const url = "https://abc/def";
+    expect(treatUrl(url)).toBe(url);
+  });
+});
+
+describe("replace placeholder and expressions", () => {
+  test("success", () => {
+    const url =
+      "https://abc/${TEST:test}/testfile%{new Number(3).toString()}.txt";
+    const treatedUrl = "https://abc/test/testfile3.txt";
+    expect(treatUrl(url)).toBe(treatedUrl);
+  });
+});


### PR DESCRIPTION
Resolves sub-task 1 of #42 

Implemented `treatUrl` in typescript. Added additional parameters `group`, `name`, and `branch` and implemented `replacePlaceholders` so that the client using the library does not have to generate placeholders on their own and can leave up to the build chain config reader (for eg: [generatePlaceholders](https://github.com/kiegroup/github-action-build-chain/blob/typescript/main/src/service/config/definition-file-reader.ts#L117) )

Refactored `executeUrlExpressions` to `replaceExpressions`. Implemented a safe version of `eval` as recommended by the [official documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval#never_use_eval!) 