### PR TITLE
[ISSUE-42] Sub Task 3 - Yaml Parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,10 @@
       "name": "build-chain-configuration-reader",
       "version": "2.2.6",
       "license": "Apache-2.0",
+      "dependencies": {
+        "ajv": "^8.11.0",
+        "yaml": "^2.1.1"
+      },
       "devDependencies": {
         "@types/jest": "^28.1.1",
         "@types/node": "^17.0.41",
@@ -630,6 +634,22 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -662,6 +682,12 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "node_modules/@eslint/eslintrc/node_modules/type-fest": {
       "version": "0.20.2",
@@ -1543,14 +1569,13 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
         "uri-js": "^4.2.2"
       },
       "funding": {
@@ -2204,6 +2229,22 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/eslint/node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -2264,6 +2305,12 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "node_modules/eslint/node_modules/locate-path": {
       "version": "6.0.0",
@@ -2430,8 +2477,7 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-glob": {
       "version": "3.2.11",
@@ -3590,10 +3636,9 @@
       "dev": true
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -4066,7 +4111,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -4114,6 +4158,14 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4674,7 +4726,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -4788,6 +4839,14 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
+    },
+    "node_modules/yaml": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.1.tgz",
+      "integrity": "sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==",
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/yargs": {
       "version": "17.5.1",
@@ -5302,6 +5361,18 @@
         "strip-json-comments": "^3.1.1"
       },
       "dependencies": {
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
         "argparse": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -5325,6 +5396,12 @@
           "requires": {
             "argparse": "^2.0.1"
           }
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
         },
         "type-fest": {
           "version": "0.20.2",
@@ -5994,14 +6071,13 @@
       "dev": true
     },
     "ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
       "requires": {
         "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
         "uri-js": "^4.2.2"
       }
     },
@@ -6456,6 +6532,18 @@
         "text-table": "^0.2.0"
       },
       "dependencies": {
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
         "argparse": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -6495,6 +6583,12 @@
           "requires": {
             "argparse": "^2.0.1"
           }
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
         },
         "locate-path": {
           "version": "6.0.0",
@@ -6641,8 +6735,7 @@
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-glob": {
       "version": "3.2.11",
@@ -7521,10 +7614,9 @@
       "dev": true
     },
     "json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -7880,8 +7972,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "queue-microtask": {
       "version": "1.2.3",
@@ -7906,6 +7997,11 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true
+    },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
     },
     "resolve": {
       "version": "1.22.1",
@@ -8264,7 +8360,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -8354,6 +8449,11 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
+    },
+    "yaml": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.1.tgz",
+      "integrity": "sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw=="
     },
     "yargs": {
       "version": "17.5.1",

--- a/package.json
+++ b/package.json
@@ -32,5 +32,9 @@
     "ts-jest": "^28.0.4",
     "ts-node": "^10.8.1",
     "typescript": "^4.7.3"
+  },
+  "dependencies": {
+    "ajv": "^8.11.0",
+    "yaml": "^2.1.1"
   }
 }

--- a/src/schema/archive-artifacts.ts
+++ b/src/schema/archive-artifacts.ts
@@ -1,0 +1,28 @@
+import { ProjectNameSchema } from "@bc-cr/schema/project-name";
+
+export const ArchiveArtifactSchema = {
+  type: "object", 
+  properties: {
+    name: {type: "string"},
+    path: {
+      type: "array",
+      items: {type: "string"}
+    },
+    "if-no-files-found": {
+      enum: ["warn", "ignore", "error"],
+      default: "warn"
+    },
+    dependencies: {
+      oneOf: [
+        {
+          enum: ["all", "none"]
+        },
+        {
+          type: "array",
+          items: ProjectNameSchema
+        }
+      ]
+    }
+  },
+  required: ["path", "if-no-files-found", "dependencies"]
+};

--- a/src/schema/build.ts
+++ b/src/schema/build.ts
@@ -1,0 +1,57 @@
+import { ArchiveArtifactSchema } from "@bc-cr/schema/archive-artifacts";
+import { ProjectNameSchema } from "@bc-cr/schema/project-name";
+
+const CommandSchema = {
+  type: "array",
+  items: {
+    type: "string",
+  },
+};
+
+const CommandLevelSchema = {
+  type: "object",
+  properties: {
+    current: CommandSchema,
+    upstream: CommandSchema,
+    downstream: CommandSchema,
+  },
+  anyOf: [
+    { required: ["current"] },
+    { required: ["upstream"] },
+    { required: ["downstream"] },
+  ],
+  additionalProperties: false,
+};
+
+export const BuildCommandSchema = {
+  type: "object",
+  properties: {
+    before: CommandLevelSchema,
+    after: CommandLevelSchema,
+    current: CommandSchema,
+    upstream: CommandSchema,
+    downstream: CommandSchema,
+  },
+  anyOf: [
+    { required: ["before"] },
+    { required: ["after"] },
+    { required: ["current"] },
+    { required: ["upstream"] },
+    { required: ["downstream"] },
+  ],
+  additionalProperties: false,
+};
+
+export const BuildSchema = {
+  type: "object",
+  properties: {
+    project: ProjectNameSchema,
+    "build-command": BuildCommandSchema,
+    "archive-artifacts": ArchiveArtifactSchema
+  },
+  required: ["project"],
+  anyOf: [
+    {required: ["build-command"]},
+    {required: ["archive-artifacts"]},
+  ],
+};

--- a/src/schema/definition-file-schema.ts
+++ b/src/schema/definition-file-schema.ts
@@ -1,0 +1,46 @@
+import { BuildCommandSchema, BuildSchema } from "@bc-cr/schema/build";
+import { DependenciesSchema } from "@bc-cr/schema/dependencies";
+import { MappingSchema } from "@bc-cr/schema/mapping";
+import { ProjectNameSchema } from "@bc-cr/schema/project-name";
+
+export const DefintionFileSchema = {
+  type: "object",
+  properties: {
+    version: { enum: ["2.1", 2.1] },
+    dependencies: {
+      oneOf: [
+        { type: "string" },
+        {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              project: ProjectNameSchema,
+              dependencies: DependenciesSchema,
+              mapping: MappingSchema,
+            },
+            required: ["project"],
+            additionalProperties: false,
+          },
+        },
+      ],
+    },
+    extends: {
+      type: "string",
+    },
+    default: {
+      type: "object",
+      properties: {
+        "build-command": BuildCommandSchema,
+      },
+      required: ["build-command"],
+      additionalProperties: false,
+    },
+    build: {
+      type: "array",
+      items: BuildSchema,
+    },
+  },
+  required: ["version", "dependencies"],
+  additionalProperties: false,
+};

--- a/src/schema/dependencies.ts
+++ b/src/schema/dependencies.ts
@@ -1,0 +1,13 @@
+import { ProjectNameSchema } from "@bc-cr/schema/project-name";
+
+export const DependenciesSchema = {
+  type: "array",
+  items: {
+    type: "object",
+    properties: {
+      project: ProjectNameSchema,
+    },
+    required: ["project"],
+    additionalProperties: false,
+  },
+};

--- a/src/schema/mapping.ts
+++ b/src/schema/mapping.ts
@@ -1,0 +1,60 @@
+import { ProjectNameSchema } from "@bc-cr/schema/project-name";
+
+const SourceToTargetSchema = {
+  type: "object",
+  properties: {
+    source: { type: "string" },
+    target: { type: "string" },
+    targetExpression: { type: "string" },
+  },
+  required: ["source"],
+  oneOf: [
+    {
+      required: ["target"],
+    },
+    {
+      required: ["targetExpression"],
+    },
+  ],
+  additionalProperties: false
+};
+
+const DependSchema = {
+  type: "object",
+  properties: {
+    default: {
+      type: "array",
+      items: SourceToTargetSchema
+    },
+  },
+  patternProperties: {
+    "^[^/]+/[^/]+$": {
+      type: "array",
+      items: SourceToTargetSchema
+    }
+  },
+  required: ["default"],
+  additionalProperties: false
+};
+
+export const MappingSchema = {
+  type: "object",
+  properties: {
+    dependencies: DependSchema,
+    dependant: DependSchema,
+    exclude: {
+      type: "array",
+      items: ProjectNameSchema,
+    },
+  },
+  required: ["exclude"],
+  anyOf: [
+    {
+      required: ["dependencies"]
+    },
+    {
+      required: ["dependant"]
+    }
+  ],
+  additionalProperties: false
+};

--- a/src/schema/project-name.ts
+++ b/src/schema/project-name.ts
@@ -1,0 +1,4 @@
+export const ProjectNameSchema = {
+  type: "string",
+  pattern: "^[^/]+/[^/]+$",
+};

--- a/src/util/yaml.ts
+++ b/src/util/yaml.ts
@@ -1,0 +1,64 @@
+import { parse } from "yaml";
+import Ajv from "ajv";
+import { DefintionFileSchema } from "@bc-cr/schema/definition-file-schema";
+
+export async function loadDefinitionFile(content: string) {
+  // parse yaml and perform some transformation on the raw json produced
+  const rawJSON = parse(content, (key: unknown, value: unknown) => {
+    // for all the below keys, if the value is a string, split it at "\n" and convert to array
+    const keys = ["path", "current", "upstream", "downstream"];
+    if (keys.includes(key as string) && typeof value === "string") {
+      return value.trim().split("\n");
+    }
+
+    if (key === "mapping") {
+      const val = value as Record<string, Record<string, unknown>>;
+      // if exclude is not defined in mapping then add an empty array
+      if (!val["exclude"]) {
+        return {
+          ...val,
+          exclude: [],
+        };
+      }
+      // if dependencies.default is not defined in mapping then add an empty array
+      if (val["dependencies"] && !val["dependencies"]["default"]) {
+        return {
+          ...val,
+          dependencies: {
+            ...val["dependencies"],
+            default: [],
+          },
+        };
+      }
+      // if dependant.default is not defined in mapping then add an empty array
+      if (val["dependant"] && !val["dependant"]["default"]) {
+        return {
+          ...val,
+          dependant: {
+            ...val["dependant"],
+            default: [],
+          },
+        };
+      }
+    }
+    if (key === "archive-artifacts") {
+      const val = value as Record<string, unknown>;
+      // if dependencies is not defined in archive-artifacts then use none by default
+      if (!val["dependencies"]) {
+        return {
+          ...val,
+          dependencies: "none",
+        };
+      }
+    }
+    return value;
+  });
+  const ajv = new Ajv({ useDefaults: "empty" });
+  const validate = ajv.compile(DefintionFileSchema);
+  const valid = validate(rawJSON);
+  if (valid) {
+    return rawJSON;
+  } else {
+    throw new Error(JSON.stringify(validate.errors));
+  }
+}

--- a/test/resources/schema-tests/backport/build-config-dependencies-url-placeholders.yaml
+++ b/test/resources/schema-tests/backport/build-config-dependencies-url-placeholders.yaml
@@ -1,0 +1,74 @@
+version: "2.1"
+dependencies: http://whateverurl.rh/${GROUP}/${PROJECT_NAME}/${BRANCH}/dependencies.yaml
+
+default:
+  build-command:
+    current: mvn -e -nsu -Dfull -Pwildfly clean install -Prun-code-coverage  -Dcontainer.profile=wildfly -Dcontainer=wildfly -Dintegration-tests=true -Dmaven.test.failure.ignore=true
+    upstream: mvn -e --builder smart -T1C clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
+    after:
+      upstream: rm -rf ./*
+
+build:
+  - project: kiegroup/appformer
+    build-command:
+      upstream: mvn -e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
+    archive-artifacts:
+      path: |
+        **/dashbuilder-runtime.war
+
+  - project: kiegroup/drools
+    build-command:
+      upstream: mvn -e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
+
+  - project: kiegroup/optaplanner
+    build-command:
+      current: mvn -e clean install -nsu -Prun-code-coverage,wildfly -Dfull  -Dintegration-tests=true -Dmaven.test.failure.ignore=true
+      upstream: mvn -e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
+
+  - project: kiegroup/droolsjbpm-integration
+    build-command:
+      current: mvn -e -nsu -Dfull -Pwildfly clean install -Pjenkins-pr-builder -Prun-code-coverage  -Dcontainer.profile=wildfly -Dcontainer=wildfly -Dintegration-tests=true -Dmaven.test.failure.ignore=true
+    archive-artifacts:
+      path: |
+        **/gclog
+
+  - project: kiegroup/kie-wb-common
+    build-command:
+      current: mvn -e -nsu -Dfull clean install -Prun-code-coverage -Pwildfly -Dcontainer=wildfly -Dcontainer.profile=wildfly -Dintegration-tests=true -Dmaven.test.failure.ignore=true -Dwebdriver.firefox.bin=/opt/tools/firefox-60esr/firefox-bin
+      upstream: -e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
+    archive-artifacts:
+      path: |
+        **/target/screenshots/**
+
+  - project: kiegroup/jbpm-wb
+    archive-artifacts:
+      path: |
+        **/target/jbpm-wb-case-mgmt-showcase*.war
+        **/target/jbpm-wb-showcase.war
+
+  - project: kiegroup/kie-docs
+    build-command:
+      current: mvn clean install
+
+  - project: kiegroup/optaweb-employee-rostering
+    archive-artifacts:
+      path: |
+        **/cypress/screenshots/**
+        **/cypress/videos/**
+
+  - project: kiegroup/optaweb-vehicle-routing
+    archive-artifacts:
+      path: |
+        **/cypress/screenshots/**
+        **/cypress/videos/**
+
+  - project: kiegroup/kie-wb-distributions
+    build-command:
+      current: mvn -e -nsu clean install -Dfull -Prun-code-coverage -Pwildfly -Dcontainer=wildfly -Dcontainer.profile=wildfly -Dintegration-tests=true -Dmaven.test.failure.ignore=true -Pbusiness-central -Dgwt.compiler.localWorkers=1 -Dwebdriver.firefox.bin=/opt/tools/firefox-60esr/firefox-bin
+    archive-artifacts:
+      path: |
+        **/target/screenshots/**
+        **/target/business-monitoring-webapp.war
+        **/target/business-central*eap*.war
+        **/target/business-central*wildfly*.war
+        **/target/jbpm-server*dist*.zip

--- a/test/resources/schema-tests/backport/build-config-dependencies-url.yaml
+++ b/test/resources/schema-tests/backport/build-config-dependencies-url.yaml
@@ -1,0 +1,74 @@
+version: "2.1"
+dependencies: http://whateverurl.rh/dependencies.yaml
+
+default:
+  build-command:
+    current: mvn -e -nsu -Dfull -Pwildfly clean install -Prun-code-coverage  -Dcontainer.profile=wildfly -Dcontainer=wildfly -Dintegration-tests=true -Dmaven.test.failure.ignore=true
+    upstream: mvn -e --builder smart -T1C clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
+    after:
+      upstream: rm -rf ./*
+
+build:
+  - project: kiegroup/appformer
+    build-command:
+      upstream: mvn -e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
+    archive-artifacts:
+      path: |
+        **/dashbuilder-runtime.war
+
+  - project: kiegroup/drools
+    build-command:
+      upstream: mvn -e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
+
+  - project: kiegroup/optaplanner
+    build-command:
+      current: mvn -e clean install -nsu -Prun-code-coverage,wildfly -Dfull  -Dintegration-tests=true -Dmaven.test.failure.ignore=true
+      upstream: mvn -e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
+
+  - project: kiegroup/droolsjbpm-integration
+    build-command:
+      current: mvn -e -nsu -Dfull -Pwildfly clean install -Pjenkins-pr-builder -Prun-code-coverage  -Dcontainer.profile=wildfly -Dcontainer=wildfly -Dintegration-tests=true -Dmaven.test.failure.ignore=true
+    archive-artifacts:
+      path: |
+        **/gclog
+
+  - project: kiegroup/kie-wb-common
+    build-command:
+      current: mvn -e -nsu -Dfull clean install -Prun-code-coverage -Pwildfly -Dcontainer=wildfly -Dcontainer.profile=wildfly -Dintegration-tests=true -Dmaven.test.failure.ignore=true -Dwebdriver.firefox.bin=/opt/tools/firefox-60esr/firefox-bin
+      upstream: -e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
+    archive-artifacts:
+      path: |
+        **/target/screenshots/**
+
+  - project: kiegroup/jbpm-wb
+    archive-artifacts:
+      path: |
+        **/target/jbpm-wb-case-mgmt-showcase*.war
+        **/target/jbpm-wb-showcase.war
+
+  - project: kiegroup/kie-docs
+    build-command:
+      current: mvn clean install
+
+  - project: kiegroup/optaweb-employee-rostering
+    archive-artifacts:
+      path: |
+        **/cypress/screenshots/**
+        **/cypress/videos/**
+
+  - project: kiegroup/optaweb-vehicle-routing
+    archive-artifacts:
+      path: |
+        **/cypress/screenshots/**
+        **/cypress/videos/**
+
+  - project: kiegroup/kie-wb-distributions
+    build-command:
+      current: mvn -e -nsu clean install -Dfull -Prun-code-coverage -Pwildfly -Dcontainer=wildfly -Dcontainer.profile=wildfly -Dintegration-tests=true -Dmaven.test.failure.ignore=true -Pbusiness-central -Dgwt.compiler.localWorkers=1 -Dwebdriver.firefox.bin=/opt/tools/firefox-60esr/firefox-bin
+    archive-artifacts:
+      path: |
+        **/target/screenshots/**
+        **/target/business-monitoring-webapp.war
+        **/target/business-central*eap*.war
+        **/target/business-central*wildfly*.war
+        **/target/jbpm-server*dist*.zip

--- a/test/resources/schema-tests/backport/build-config-from-dependencies-extension.yaml
+++ b/test/resources/schema-tests/backport/build-config-from-dependencies-extension.yaml
@@ -1,0 +1,75 @@
+version: "2.1"
+
+dependencies: ./project-dependencies-extension2.yaml
+
+default:
+  build-command:
+    current: mvn -e -nsu -Dfull -Pwildfly clean install -Prun-code-coverage  -Dcontainer.profile=wildfly -Dcontainer=wildfly -Dintegration-tests=true -Dmaven.test.failure.ignore=true
+    upstream: mvn -e --builder smart -T1C clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
+    after:
+      upstream: rm -rf ./*
+
+build:
+  - project: kiegroup/appformer
+    build-command:
+      upstream: mvn -e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
+    archive-artifacts:
+      path: |
+        **/dashbuilder-runtime.war
+
+  - project: kiegroup/drools
+    build-command:
+      upstream: mvn -e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
+
+  - project: kiegroup/optaplanner
+    build-command:
+      current: mvn -e clean install -nsu -Prun-code-coverage,wildfly -Dfull  -Dintegration-tests=true -Dmaven.test.failure.ignore=true
+      upstream: mvn -e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
+
+  - project: kiegroup/droolsjbpm-integration
+    build-command:
+      current: mvn -e -nsu -Dfull -Pwildfly clean install -Pjenkins-pr-builder -Prun-code-coverage  -Dcontainer.profile=wildfly -Dcontainer=wildfly -Dintegration-tests=true -Dmaven.test.failure.ignore=true
+    archive-artifacts:
+      path: |
+        **/gclog
+
+  - project: kiegroup/kie-wb-common
+    build-command:
+      current: mvn -e -nsu -Dfull clean install -Prun-code-coverage -Pwildfly -Dcontainer=wildfly -Dcontainer.profile=wildfly -Dintegration-tests=true -Dmaven.test.failure.ignore=true -Dwebdriver.firefox.bin=/opt/tools/firefox-60esr/firefox-bin
+      upstream: -e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
+    archive-artifacts:
+      path: |
+        **/target/screenshots/**
+
+  - project: kiegroup/jbpm-wb
+    archive-artifacts:
+      path: |
+        **/target/jbpm-wb-case-mgmt-showcase*.war
+        **/target/jbpm-wb-showcase.war
+
+  - project: kiegroup/kie-docs
+    build-command:
+      current: mvn clean install
+
+  - project: kiegroup/optaweb-employee-rostering
+    archive-artifacts:
+      path: |
+        **/cypress/screenshots/**
+        **/cypress/videos/**
+
+  - project: kiegroup/optaweb-vehicle-routing
+    archive-artifacts:
+      path: |
+        **/cypress/screenshots/**
+        **/cypress/videos/**
+
+  - project: kiegroup/kie-wb-distributions
+    build-command:
+      current: mvn -e -nsu clean install -Dfull -Prun-code-coverage -Pwildfly -Dcontainer=wildfly -Dcontainer.profile=wildfly -Dintegration-tests=true -Dmaven.test.failure.ignore=true -Pbusiness-central -Dgwt.compiler.localWorkers=1 -Dwebdriver.firefox.bin=/opt/tools/firefox-60esr/firefox-bin
+    archive-artifacts:
+      path: |
+        **/target/screenshots/**
+        **/target/business-monitoring-webapp.war
+        **/target/business-central*eap*.war
+        **/target/business-central*wildfly*.war
+        **/target/jbpm-server*dist*.zip

--- a/test/resources/schema-tests/backport/build-config-with-dependencies-for-example.yaml
+++ b/test/resources/schema-tests/backport/build-config-with-dependencies-for-example.yaml
@@ -1,0 +1,241 @@
+version: "2.1"
+
+dependencies:
+  - project: kiegroup/lienzo-core
+
+  - project: kiegroup/lienzo-tests
+    dependencies:
+      - project: kiegroup/lienzo-core
+
+  - project: kiegroup/droolsjbpm-build-bootstrap
+    dependencies:
+      - project: kiegroup/lienzo-core
+
+  - project: kiegroup/kie-soup
+    dependencies:
+      - project: kiegroup/droolsjbpm-build-bootstrap
+
+  - project: kiegroup/appformer
+    dependencies:
+      - project: kiegroup/droolsjbpm-build-bootstrap
+      - project: kiegroup/lienzo-tests
+      - project: kiegroup/kie-soup
+
+  - project: kiegroup/droolsjbpm-knowledge
+    dependencies:
+      - project: kiegroup/kie-soup
+
+  - project: kiegroup/drools
+    dependencies:
+      - project: kiegroup/appformer
+      - project: kiegroup/kie-soup
+
+  - project: kiegroup/jbpm
+    dependencies:
+      - project: kiegroup/drools
+      - project: kiegroup/kie-soup
+
+  - project: kiegroup/optaplanner
+    dependencies:
+      - project: kiegroup/drools
+      - project: kiegroup/jbpm
+    mapping:
+      dependencies:
+        default:
+          - source: 7.x
+            target: main
+      dependant:
+        default:
+          - source: main
+            target: 7.x
+      exclude:
+        - kiegroup/optaweb-employee-rostering
+        - kiegroup/optaweb-vehicle-routing
+
+  - project: kiegroup/kie-jpmml-integration
+    dependencies:
+      - project: kiegroup/drools
+      - project: kiegroup/jbpm
+
+  - project: kiegroup/droolsjbpm-integration
+    dependencies:
+      - project: kiegroup/optaplanner
+      - project: kiegroup/kie-jpmml-integration
+      - project: kiegroup/jbpm
+      - project: kiegroup/kie-soup
+
+  - project: kiegroup/openshift-drools-hacep
+    dependencies:
+      - project: kiegroup/droolsjbpm-integration
+
+  - project: kiegroup/droolsjbpm-tools
+    dependencies:
+      - project: kiegroup/jbpm
+      - project: kiegroup/drools
+      - project: kiegroup/kie-soup
+
+  - project: kiegroup/kie-uberfire-extensions
+    dependencies:
+      - project: kiegroup/appformer
+
+  - project: kiegroup/kie-wb-playground
+    dependencies:
+      - project: kiegroup/openshift-drools-hacep
+
+  - project: kiegroup/kie-wb-common
+    dependencies:
+      - project: kiegroup/kie-wb-playground
+      - project: kiegroup/droolsjbpm-integration
+
+  - project: kiegroup/drools-wb
+    dependencies:
+      - project: kiegroup/kie-wb-common
+
+  - project: kiegroup/optaplanner-wb
+    dependencies:
+      - project: kiegroup/appformer
+      - project: kiegroup/kie-uberfire-extensions
+      - project: kiegroup/drools-wb
+      - project: kiegroup/drools
+      - project: kiegroup/optaplanner
+      - project: kiegroup/kie-soup
+      - project: kiegroup/kie-wb-common
+      - project: kiegroup/kie-wb-playground
+
+  - project: kiegroup/jbpm-designer
+    dependencies:
+      - project: kiegroup/kie-wb-common
+
+  - project: kiegroup/jbpm-work-items
+    dependencies:
+      - project: kiegroup/openshift-drools-hacep
+      - project: kiegroup/kie-wb-playground
+
+  - project: kiegroup/jbpm-wb
+    dependencies:
+      - project: kiegroup/kie-uberfire-extensions
+      - project: kiegroup/drools-wb
+      - project: kiegroup/jbpm-designer
+      - project: kiegroup/jbpm-work-items
+
+  - project: kiegroup/kie-docs
+
+  - project: kiegroup/optaweb-employee-rostering
+    dependencies:
+      - project: kiegroup/optaplanner
+    mapping:
+      dependencies:
+        default:
+          - source: 7.x
+            target: main
+      dependant:
+        default:
+          - source: main
+            target: 7.x
+      exclude:
+        - kiegroup/optaweb-vehicle-routing
+        - kiegroup/optaplanner
+
+  - project: kiegroup/optaweb-vehicle-routing
+    dependencies:
+      - project: kiegroup/optaplanner
+    mapping:
+      dependencies:
+        default:
+          - source: 7.x
+            target: main
+      dependant:
+        default:
+          - source: main
+            target: 7.x
+      exclude:
+        - kiegroup/optaweb-employee-rostering
+        - kiegroup/optaplanner
+
+  - project: kiegroup/kie-wb-distributions
+    dependencies:
+      - project: kiegroup/appformer
+      - project: kiegroup/kie-soup
+      - project: kiegroup/drools
+      - project: kiegroup/optaplanner
+      - project: kiegroup/jbpm
+      - project: kiegroup/kie-uberfire-extensions
+      - project: kiegroup/jbpm-wb
+
+default:
+  build-command:
+    current: |
+      mvn clean
+      mvn install
+    upstream: mvn -e --builder smart -T1C clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
+    after:
+      upstream: rm -rf ./*
+
+build:
+  - project: kiegroup/appformer
+    build-command:
+      upstream: mvn -e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
+    archive-artifacts:
+      path: |
+        **/dashbuilder-runtime.war
+
+  - project: kiegroup/drools
+    build-command:
+      upstream: mvn -e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
+
+  - project: kiegroup/optaplanner
+    build-command:
+      current: mvn -e clean install -nsu -Prun-code-coverage,wildfly -Dfull  -Dintegration-tests=true -Dmaven.test.failure.ignore=true
+      upstream: mvn -e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
+
+  - project: kiegroup/droolsjbpm-integration
+    build-command:
+      current: mvn -e -nsu -Dfull -Pwildfly clean install -Pjenkins-pr-builder -Prun-code-coverage  -Dcontainer.profile=wildfly -Dcontainer=wildfly -Dintegration-tests=true -Dmaven.test.failure.ignore=true
+    archive-artifacts:
+      path: |
+        **/gclog
+
+  - project: kiegroup/kie-wb-common
+    build-command:
+      current: mvn -e -nsu -Dfull clean install -Prun-code-coverage -Pwildfly -Dcontainer=wildfly -Dcontainer.profile=wildfly -Dintegration-tests=true -Dmaven.test.failure.ignore=true -Dwebdriver.firefox.bin=/opt/tools/firefox-60esr/firefox-bin
+      upstream: -e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
+    archive-artifacts:
+      path: |
+        **/target/screenshots/**
+
+  - project: kiegroup/jbpm-wb
+    archive-artifacts:
+      path: |
+        **/target/jbpm-wb-case-mgmt-showcase*.war
+        **/target/jbpm-wb-showcase.war
+
+  - project: kiegroup/kie-docs
+    build-command:
+      current: mvn clean install
+    skip: true
+
+  - project: kiegroup/optaweb-employee-rostering
+    archive-artifacts:
+      path: |
+        **/cypress/screenshots/**
+        **/cypress/videos/**
+
+  - project: kiegroup/optaweb-vehicle-routing
+    archive-artifacts:
+      path: |
+        **/cypress/screenshots/**
+        **/cypress/videos/**
+
+  - project: kiegroup/kie-wb-distributions
+    build-command:
+      current: |
+        mvn -e -nsu clean install -Dfull -Prun-code-coverage -Pwildfly -Dcontainer=wildfly -Dcontainer.profile=wildfly -Dintegration-tests=true -Dmaven.test.failure.ignore=true -Pbusiness-central -Dgwt.compiler.localWorkers=1 -Dwebdriver.firefox.bin=/opt/tools/firefox-60esr/firefox-bin
+        mvn 1
+        mvn 2
+    archive-artifacts:
+      path: |
+        **/target/screenshots/**
+        **/target/business-monitoring-webapp.war
+        **/target/business-central*eap*.war
+        **/target/business-central*wildfly*.war
+        **/target/jbpm-server*dist*.zip

--- a/test/resources/schema-tests/backport/build-config-with-dependencies.yaml
+++ b/test/resources/schema-tests/backport/build-config-with-dependencies.yaml
@@ -1,0 +1,240 @@
+version: "2.1"
+
+dependencies:
+  - project: kiegroup/lienzo-core
+
+  - project: kiegroup/lienzo-tests
+    dependencies:
+      - project: kiegroup/lienzo-core
+
+  - project: kiegroup/droolsjbpm-build-bootstrap
+    dependencies:
+      - project: kiegroup/lienzo-core
+
+  - project: kiegroup/kie-soup
+    dependencies:
+      - project: kiegroup/droolsjbpm-build-bootstrap
+
+  - project: kiegroup/appformer
+    dependencies:
+      - project: kiegroup/droolsjbpm-build-bootstrap
+      - project: kiegroup/lienzo-tests
+      - project: kiegroup/kie-soup
+
+  - project: kiegroup/droolsjbpm-knowledge
+    dependencies:
+      - project: kiegroup/kie-soup
+
+  - project: kiegroup/drools
+    dependencies:
+      - project: kiegroup/appformer
+      - project: kiegroup/kie-soup
+
+  - project: kiegroup/jbpm
+    dependencies:
+      - project: kiegroup/drools
+      - project: kiegroup/kie-soup
+
+  - project: kiegroup/optaplanner
+    dependencies:
+      - project: kiegroup/drools
+      - project: kiegroup/jbpm
+    mapping:
+      dependencies:
+        default:
+          - source: 7.x
+            target: main
+      dependant:
+        default:
+          - source: main
+            target: 7.x
+      exclude:
+        - kiegroup/optaweb-employee-rostering
+        - kiegroup/optaweb-vehicle-routing
+
+  - project: kiegroup/kie-jpmml-integration
+    dependencies:
+      - project: kiegroup/drools
+      - project: kiegroup/jbpm
+
+  - project: kiegroup/droolsjbpm-integration
+    dependencies:
+      - project: kiegroup/optaplanner
+      - project: kiegroup/kie-jpmml-integration
+      - project: kiegroup/jbpm
+      - project: kiegroup/kie-soup
+
+  - project: kiegroup/openshift-drools-hacep
+    dependencies:
+      - project: kiegroup/droolsjbpm-integration
+
+  - project: kiegroup/droolsjbpm-tools
+    dependencies:
+      - project: kiegroup/jbpm
+      - project: kiegroup/drools
+      - project: kiegroup/kie-soup
+
+  - project: kiegroup/kie-uberfire-extensions
+    dependencies:
+      - project: kiegroup/appformer
+
+  - project: kiegroup/kie-wb-playground
+    dependencies:
+      - project: kiegroup/openshift-drools-hacep
+
+  - project: kiegroup/kie-wb-common
+    dependencies:
+      - project: kiegroup/kie-wb-playground
+      - project: kiegroup/droolsjbpm-integration
+
+  - project: kiegroup/drools-wb
+    dependencies:
+      - project: kiegroup/kie-wb-common
+
+  - project: kiegroup/optaplanner-wb
+    dependencies:
+      - project: kiegroup/appformer
+      - project: kiegroup/kie-uberfire-extensions
+      - project: kiegroup/drools-wb
+      - project: kiegroup/drools
+      - project: kiegroup/optaplanner
+      - project: kiegroup/kie-soup
+      - project: kiegroup/kie-wb-common
+      - project: kiegroup/kie-wb-playground
+
+  - project: kiegroup/jbpm-designer
+    dependencies:
+      - project: kiegroup/kie-wb-common
+
+  - project: kiegroup/jbpm-work-items
+    dependencies:
+      - project: kiegroup/openshift-drools-hacep
+      - project: kiegroup/kie-wb-playground
+
+  - project: kiegroup/jbpm-wb
+    dependencies:
+      - project: kiegroup/kie-uberfire-extensions
+      - project: kiegroup/drools-wb
+      - project: kiegroup/jbpm-designer
+      - project: kiegroup/jbpm-work-items
+
+  - project: kiegroup/kie-docs
+
+  - project: kiegroup/optaweb-employee-rostering
+    dependencies:
+      - project: kiegroup/optaplanner
+    mapping:
+      dependencies:
+        default:
+          - source: 7.x
+            target: main
+      dependant:
+        default:
+          - source: main
+            target: 7.x
+      exclude:
+        - kiegroup/optaweb-vehicle-routing
+        - kiegroup/optaplanner
+
+  - project: kiegroup/optaweb-vehicle-routing
+    dependencies:
+      - project: kiegroup/optaplanner
+    mapping:
+      dependencies:
+        default:
+          - source: 7.x
+            target: main
+      dependant:
+        default:
+          - source: main
+            target: 7.x
+      exclude:
+        - kiegroup/optaweb-employee-rostering
+        - kiegroup/optaplanner
+
+  - project: kiegroup/kie-wb-distributions
+    dependencies:
+      - project: kiegroup/appformer
+      - project: kiegroup/kie-soup
+      - project: kiegroup/drools
+      - project: kiegroup/optaplanner
+      - project: kiegroup/jbpm
+      - project: kiegroup/kie-uberfire-extensions
+      - project: kiegroup/jbpm-wb
+
+default:
+  build-command:
+    current: |
+      mvn clean
+      mvn install
+    upstream: mvn -e --builder smart -T1C clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
+    after:
+      upstream: rm -rf ./*
+
+build:
+  - project: kiegroup/appformer
+    build-command:
+      upstream: mvn -e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
+    archive-artifacts:
+      path: |
+        **/dashbuilder-runtime.war
+
+  - project: kiegroup/drools
+    build-command:
+      upstream: mvn -e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
+
+  - project: kiegroup/optaplanner
+    build-command:
+      current: mvn -e clean install -nsu -Prun-code-coverage,wildfly -Dfull  -Dintegration-tests=true -Dmaven.test.failure.ignore=true
+      upstream: mvn -e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
+
+  - project: kiegroup/droolsjbpm-integration
+    build-command:
+      current: mvn -e -nsu -Dfull -Pwildfly clean install -Pjenkins-pr-builder -Prun-code-coverage  -Dcontainer.profile=wildfly -Dcontainer=wildfly -Dintegration-tests=true -Dmaven.test.failure.ignore=true
+    archive-artifacts:
+      path: |
+        **/gclog
+
+  - project: kiegroup/kie-wb-common
+    build-command:
+      current: mvn -e -nsu -Dfull clean install -Prun-code-coverage -Pwildfly -Dcontainer=wildfly -Dcontainer.profile=wildfly -Dintegration-tests=true -Dmaven.test.failure.ignore=true -Dwebdriver.firefox.bin=/opt/tools/firefox-60esr/firefox-bin
+      upstream: -e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
+    archive-artifacts:
+      path: |
+        **/target/screenshots/**
+
+  - project: kiegroup/jbpm-wb
+    archive-artifacts:
+      path: |
+        **/target/jbpm-wb-case-mgmt-showcase*.war
+        **/target/jbpm-wb-showcase.war
+
+  - project: kiegroup/kie-docs
+    build-command:
+      current: mvn clean install
+
+  - project: kiegroup/optaweb-employee-rostering
+    archive-artifacts:
+      path: |
+        **/cypress/screenshots/**
+        **/cypress/videos/**
+
+  - project: kiegroup/optaweb-vehicle-routing
+    archive-artifacts:
+      path: |
+        **/cypress/screenshots/**
+        **/cypress/videos/**
+
+  - project: kiegroup/kie-wb-distributions
+    build-command:
+      current: |
+        mvn -e -nsu clean install -Dfull -Prun-code-coverage -Pwildfly -Dcontainer=wildfly -Dcontainer.profile=wildfly -Dintegration-tests=true -Dmaven.test.failure.ignore=true -Pbusiness-central -Dgwt.compiler.localWorkers=1 -Dwebdriver.firefox.bin=/opt/tools/firefox-60esr/firefox-bin
+        mvn 1
+        mvn 2
+    archive-artifacts:
+      path: |
+        **/target/screenshots/**
+        **/target/business-monitoring-webapp.war
+        **/target/business-central*eap*.war
+        **/target/business-central*wildfly*.war
+        **/target/jbpm-server*dist*.zip

--- a/test/resources/schema-tests/backport/build-config.yaml
+++ b/test/resources/schema-tests/backport/build-config.yaml
@@ -1,0 +1,75 @@
+version: "2.1"
+
+dependencies: ./project-dependencies.yaml
+
+default:
+  build-command:
+    current: mvn -e -nsu -Dfull -Pwildfly clean install -Prun-code-coverage  -Dcontainer.profile=wildfly -Dcontainer=wildfly -Dintegration-tests=true -Dmaven.test.failure.ignore=true
+    upstream: mvn -e --builder smart -T1C clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
+    after:
+      upstream: rm -rf ./*
+
+build:
+  - project: kiegroup/appformer
+    build-command:
+      upstream: mvn -e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
+    archive-artifacts:
+      path: |
+        **/dashbuilder-runtime.war
+
+  - project: kiegroup/drools
+    build-command:
+      upstream: mvn -e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
+
+  - project: kiegroup/optaplanner
+    build-command:
+      current: mvn -e clean install -nsu -Prun-code-coverage,wildfly -Dfull  -Dintegration-tests=true -Dmaven.test.failure.ignore=true
+      upstream: mvn -e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
+
+  - project: kiegroup/droolsjbpm-integration
+    build-command:
+      current: mvn -e -nsu -Dfull -Pwildfly clean install -Pjenkins-pr-builder -Prun-code-coverage  -Dcontainer.profile=wildfly -Dcontainer=wildfly -Dintegration-tests=true -Dmaven.test.failure.ignore=true
+    archive-artifacts:
+      path: |
+        **/gclog
+
+  - project: kiegroup/kie-wb-common
+    build-command:
+      current: mvn -e -nsu -Dfull clean install -Prun-code-coverage -Pwildfly -Dcontainer=wildfly -Dcontainer.profile=wildfly -Dintegration-tests=true -Dmaven.test.failure.ignore=true -Dwebdriver.firefox.bin=/opt/tools/firefox-60esr/firefox-bin
+      upstream: -e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
+    archive-artifacts:
+      path: |
+        **/target/screenshots/**
+
+  - project: kiegroup/jbpm-wb
+    archive-artifacts:
+      path: |
+        **/target/jbpm-wb-case-mgmt-showcase*.war
+        **/target/jbpm-wb-showcase.war
+
+  - project: kiegroup/kie-docs
+    build-command:
+      current: mvn clean install
+
+  - project: kiegroup/optaweb-employee-rostering
+    archive-artifacts:
+      path: |
+        **/cypress/screenshots/**
+        **/cypress/videos/**
+
+  - project: kiegroup/optaweb-vehicle-routing
+    archive-artifacts:
+      path: |
+        **/cypress/screenshots/**
+        **/cypress/videos/**
+
+  - project: kiegroup/kie-wb-distributions
+    build-command:
+      current: mvn -e -nsu clean install -Dfull -Prun-code-coverage -Pwildfly -Dcontainer=wildfly -Dcontainer.profile=wildfly -Dintegration-tests=true -Dmaven.test.failure.ignore=true -Pbusiness-central -Dgwt.compiler.localWorkers=1 -Dwebdriver.firefox.bin=/opt/tools/firefox-60esr/firefox-bin
+    archive-artifacts:
+      path: |
+        **/target/screenshots/**
+        **/target/business-monitoring-webapp.war
+        **/target/business-central*eap*.war
+        **/target/business-central*wildfly*.war
+        **/target/jbpm-server*dist*.zip

--- a/test/resources/schema-tests/backport/project-dependencies-exclude.yaml
+++ b/test/resources/schema-tests/backport/project-dependencies-exclude.yaml
@@ -1,0 +1,170 @@
+version: "2.1"
+dependencies:
+  - project: kiegroup/lienzo-core
+
+  - project: kiegroup/lienzo-tests
+    dependencies:
+      - project: kiegroup/lienzo-core
+
+  - project: kiegroup/droolsjbpm-build-bootstrap
+
+  - project: kiegroup/kie-soup
+    dependencies:
+      - project: kiegroup/droolsjbpm-build-bootstrap
+
+  - project: kiegroup/appformer
+    dependencies:
+      - project: kiegroup/lienzo-core
+      - project: kiegroup/droolsjbpm-build-bootstrap
+      - project: kiegroup/lienzo-tests
+      - project: kiegroup/kie-soup
+
+  - project: kiegroup/droolsjbpm-knowledge
+    dependencies:
+      - project: kiegroup/kie-soup
+
+  - project: kiegroup/drools
+    dependencies:
+      - project: kiegroup/kie-soup
+
+  - project: kiegroup/jbpm
+    dependencies:
+      - project: kiegroup/drools
+      - project: kiegroup/kie-soup
+
+  - project: kiegroup/optaplanner
+    dependencies:
+      - project: kiegroup/drools
+      - project: kiegroup/jbpm
+    mapping:
+      dependencies:
+        default:
+          - source: 7.x
+            targetExpression: "5+8"
+      dependant:
+        default:
+          - source: main
+            targetExpression: "`${mapping.source}-x`"
+          - source: main
+            targetExpression: "`${mapping.source}-xy`"
+        projectx/ownerx:
+          - source: ^((?!main).)*$
+            targetExpression: "5+9"
+        projecty/ownerx:
+          - source: 7.x
+            targetExpression: "throw new Error('error')"
+      exclude:
+        - kiegroup/optaweb-employee-rostering
+        - kiegroup/optaweb-vehicle-routing
+
+  - project: kiegroup/kie-jpmml-integration
+    dependencies:
+      - project: kiegroup/drools
+      - project: kiegroup/jbpm
+
+  - project: kiegroup/droolsjbpm-integration
+    dependencies:
+      - project: kiegroup/optaplanner
+      - project: kiegroup/kie-jpmml-integration
+      - project: kiegroup/jbpm
+      - project: kiegroup/kie-soup
+
+  - project: kiegroup/openshift-drools-hacep
+    dependencies:
+      - project: kiegroup/droolsjbpm-integration
+
+  - project: kiegroup/droolsjbpm-tools
+    dependencies:
+      - project: kiegroup/jbpm
+      - project: kiegroup/drools
+      - project: kiegroup/kie-soup
+
+  - project: kiegroup/kie-uberfire-extensions
+    dependencies:
+      - project: kiegroup/appformer
+
+  - project: kiegroup/kie-wb-playground
+    dependencies:
+      - project: kiegroup/openshift-drools-hacep
+
+  - project: kiegroup/kie-wb-common
+    dependencies:
+      - project: kiegroup/lienzo-core
+      - project: kiegroup/kie-wb-playground
+      - project: kiegroup/droolsjbpm-integration
+
+  - project: kiegroup/drools-wb
+    dependencies:
+      - project: kiegroup/lienzo-core
+      - project: kiegroup/kie-wb-common
+
+  - project: kiegroup/optaplanner-wb
+    dependencies:
+      - project: kiegroup/appformer
+      - project: kiegroup/kie-uberfire-extensions
+      - project: kiegroup/drools-wb
+      - project: kiegroup/drools
+      - project: kiegroup/optaplanner
+      - project: kiegroup/kie-soup
+      - project: kiegroup/kie-wb-common
+      - project: kiegroup/kie-wb-playground
+
+  - project: kiegroup/jbpm-designer
+    dependencies:
+      - project: kiegroup/kie-wb-common
+
+  - project: kiegroup/jbpm-work-items
+    dependencies:
+      - project: kiegroup/openshift-drools-hacep
+      - project: kiegroup/kie-wb-playground
+
+  - project: kiegroup/jbpm-wb
+    dependencies:
+      - project: kiegroup/kie-uberfire-extensions
+      - project: kiegroup/drools-wb
+      - project: kiegroup/jbpm-designer
+      - project: kiegroup/jbpm-work-items
+
+  - project: kiegroup/kie-docs
+
+  - project: kiegroup/optaweb-employee-rostering
+    dependencies:
+      - project: kiegroup/optaplanner
+    mapping:
+      dependencies:
+        default:
+          - source: 7.x
+            target: main
+      dependant:
+        default:
+          - source: main
+            target: 7.x
+      exclude:
+        - kiegroup/optaweb-vehicle-routing
+        - kiegroup/optaplanner
+
+  - project: kiegroup/optaweb-vehicle-routing
+    dependencies:
+      - project: kiegroup/optaplanner
+    mapping:
+      dependencies:
+        default:
+          - source: 7.x
+            target: main
+      dependant:
+        default:
+          - source: main
+            target: 7.x
+      exclude:
+        - kiegroup/optaweb-employee-rostering
+        - kiegroup/optaplanner
+
+  - project: kiegroup/kie-wb-distributions
+    dependencies:
+      - project: kiegroup/appformer
+      - project: kiegroup/kie-soup
+      - project: kiegroup/drools
+      - project: kiegroup/optaplanner
+      - project: kiegroup/jbpm
+      - project: kiegroup/kie-uberfire-extensions
+      - project: kiegroup/jbpm-wb

--- a/test/resources/schema-tests/backport/project-dependencies-extension.yaml
+++ b/test/resources/schema-tests/backport/project-dependencies-extension.yaml
@@ -1,0 +1,7 @@
+version: "2.1"
+extends: ./project-dependencies.yaml
+dependencies:
+  - project: kiegroup/projectx
+  - project: kiegroup/projecty
+    dependencies:
+      - project: kiegroup/projectx

--- a/test/resources/schema-tests/backport/project-dependencies-extension2.yaml
+++ b/test/resources/schema-tests/backport/project-dependencies-extension2.yaml
@@ -1,0 +1,6 @@
+version: "2.1"
+extends: ./project-dependencies-extension.yaml
+dependencies:
+  - project: kiegroup/projectz
+    dependencies:
+      - project: kiegroup/projectx

--- a/test/resources/schema-tests/backport/project-dependencies-target-expression.yaml
+++ b/test/resources/schema-tests/backport/project-dependencies-target-expression.yaml
@@ -1,0 +1,170 @@
+version: "2.1"
+dependencies:
+  - project: kiegroup/lienzo-core
+
+  - project: kiegroup/lienzo-tests
+    dependencies:
+      - project: kiegroup/lienzo-core
+
+  - project: kiegroup/droolsjbpm-build-bootstrap
+
+  - project: kiegroup/kie-soup
+    dependencies:
+      - project: kiegroup/droolsjbpm-build-bootstrap
+
+  - project: kiegroup/appformer
+    dependencies:
+      - project: kiegroup/lienzo-core
+      - project: kiegroup/droolsjbpm-build-bootstrap
+      - project: kiegroup/lienzo-tests
+      - project: kiegroup/kie-soup
+
+  - project: kiegroup/droolsjbpm-knowledge
+    dependencies:
+      - project: kiegroup/kie-soup
+
+  - project: kiegroup/drools
+    dependencies:
+      - project: kiegroup/kie-soup
+
+  - project: kiegroup/jbpm
+    dependencies:
+      - project: kiegroup/drools
+      - project: kiegroup/kie-soup
+
+  - project: kiegroup/optaplanner
+    dependencies:
+      - project: kiegroup/drools
+      - project: kiegroup/jbpm
+    mapping:
+      dependencies:
+        default:
+          - source: 7.x
+            targetExpression: "5+8"
+      dependant:
+        default:
+          - source: main
+            targetExpression: "`${mapping.source}-x`"
+          - source: main
+            targetExpression: "`${mapping.source}-xy`"
+        projectx/ownerx:
+          - source: ^((?!main).)*$
+            targetExpression: "5+9"
+        projecty/ownery:
+          - source: 7.x
+            targetExpression: "throw new Error('error')"
+      exclude:
+        - kiegroup/optaweb-employee-rostering
+        - kiegroup/optaweb-vehicle-routing
+
+  - project: kiegroup/kie-jpmml-integration
+    dependencies:
+      - project: kiegroup/drools
+      - project: kiegroup/jbpm
+
+  - project: kiegroup/droolsjbpm-integration
+    dependencies:
+      - project: kiegroup/optaplanner
+      - project: kiegroup/kie-jpmml-integration
+      - project: kiegroup/jbpm
+      - project: kiegroup/kie-soup
+
+  - project: kiegroup/openshift-drools-hacep
+    dependencies:
+      - project: kiegroup/droolsjbpm-integration
+
+  - project: kiegroup/droolsjbpm-tools
+    dependencies:
+      - project: kiegroup/jbpm
+      - project: kiegroup/drools
+      - project: kiegroup/kie-soup
+
+  - project: kiegroup/kie-uberfire-extensions
+    dependencies:
+      - project: kiegroup/appformer
+
+  - project: kiegroup/kie-wb-playground
+    dependencies:
+      - project: kiegroup/openshift-drools-hacep
+
+  - project: kiegroup/kie-wb-common
+    dependencies:
+      - project: kiegroup/lienzo-core
+      - project: kiegroup/kie-wb-playground
+      - project: kiegroup/droolsjbpm-integration
+
+  - project: kiegroup/drools-wb
+    dependencies:
+      - project: kiegroup/lienzo-core
+      - project: kiegroup/kie-wb-common
+
+  - project: kiegroup/optaplanner-wb
+    dependencies:
+      - project: kiegroup/appformer
+      - project: kiegroup/kie-uberfire-extensions
+      - project: kiegroup/drools-wb
+      - project: kiegroup/drools
+      - project: kiegroup/optaplanner
+      - project: kiegroup/kie-soup
+      - project: kiegroup/kie-wb-common
+      - project: kiegroup/kie-wb-playground
+
+  - project: kiegroup/jbpm-designer
+    dependencies:
+      - project: kiegroup/kie-wb-common
+
+  - project: kiegroup/jbpm-work-items
+    dependencies:
+      - project: kiegroup/openshift-drools-hacep
+      - project: kiegroup/kie-wb-playground
+
+  - project: kiegroup/jbpm-wb
+    dependencies:
+      - project: kiegroup/kie-uberfire-extensions
+      - project: kiegroup/drools-wb
+      - project: kiegroup/jbpm-designer
+      - project: kiegroup/jbpm-work-items
+
+  - project: kiegroup/kie-docs
+
+  - project: kiegroup/optaweb-employee-rostering
+    dependencies:
+      - project: kiegroup/optaplanner
+    mapping:
+      dependencies:
+        default:
+          - source: 7.x
+            target: main
+      dependant:
+        default:
+          - source: main
+            target: 7.x
+      exclude:
+        - kiegroup/optaweb-vehicle-routing
+        - kiegroup/optaplanner
+
+  - project: kiegroup/optaweb-vehicle-routing
+    dependencies:
+      - project: kiegroup/optaplanner
+    mapping:
+      dependencies:
+        default:
+          - source: 7.x
+            target: main
+      dependant:
+        default:
+          - source: main
+            target: 7.x
+      exclude:
+        - kiegroup/optaweb-employee-rostering
+        - kiegroup/optaplanner
+
+  - project: kiegroup/kie-wb-distributions
+    dependencies:
+      - project: kiegroup/appformer
+      - project: kiegroup/kie-soup
+      - project: kiegroup/drools
+      - project: kiegroup/optaplanner
+      - project: kiegroup/jbpm
+      - project: kiegroup/kie-uberfire-extensions
+      - project: kiegroup/jbpm-wb

--- a/test/resources/schema-tests/backport/project-dependencies.yaml
+++ b/test/resources/schema-tests/backport/project-dependencies.yaml
@@ -1,0 +1,162 @@
+version: "2.1"
+dependencies:
+  - project: kiegroup/lienzo-core
+
+  - project: kiegroup/lienzo-tests
+    dependencies:
+      - project: kiegroup/lienzo-core
+
+  - project: kiegroup/droolsjbpm-build-bootstrap
+
+  - project: kiegroup/kie-soup
+    dependencies:
+      - project: kiegroup/droolsjbpm-build-bootstrap
+
+  - project: kiegroup/appformer
+    dependencies:
+      - project: kiegroup/lienzo-core
+      - project: kiegroup/droolsjbpm-build-bootstrap
+      - project: kiegroup/lienzo-tests
+      - project: kiegroup/kie-soup
+
+  - project: kiegroup/droolsjbpm-knowledge
+    dependencies:
+      - project: kiegroup/kie-soup
+
+  - project: kiegroup/drools
+    dependencies:
+      - project: kiegroup/kie-soup
+
+  - project: kiegroup/jbpm
+    dependencies:
+      - project: kiegroup/drools
+      - project: kiegroup/kie-soup
+
+  - project: kiegroup/optaplanner
+    dependencies:
+      - project: kiegroup/drools
+      - project: kiegroup/jbpm
+    mapping:
+      dependencies:
+        default:
+          - source: 7.x
+            target: main
+      dependant:
+        default:
+          - source: main
+            target: 7.x
+      exclude:
+        - kiegroup/optaweb-employee-rostering
+        - kiegroup/optaweb-vehicle-routing
+
+  - project: kiegroup/kie-jpmml-integration
+    dependencies:
+      - project: kiegroup/drools
+      - project: kiegroup/jbpm
+
+  - project: kiegroup/droolsjbpm-integration
+    dependencies:
+      - project: kiegroup/optaplanner
+      - project: kiegroup/kie-jpmml-integration
+      - project: kiegroup/jbpm
+      - project: kiegroup/kie-soup
+
+  - project: kiegroup/openshift-drools-hacep
+    dependencies:
+      - project: kiegroup/droolsjbpm-integration
+
+  - project: kiegroup/droolsjbpm-tools
+    dependencies:
+      - project: kiegroup/jbpm
+      - project: kiegroup/drools
+      - project: kiegroup/kie-soup
+
+  - project: kiegroup/kie-uberfire-extensions
+    dependencies:
+      - project: kiegroup/appformer
+
+  - project: kiegroup/kie-wb-playground
+    dependencies:
+      - project: kiegroup/openshift-drools-hacep
+
+  - project: kiegroup/kie-wb-common
+    dependencies:
+      - project: kiegroup/lienzo-core
+      - project: kiegroup/kie-wb-playground
+      - project: kiegroup/droolsjbpm-integration
+
+  - project: kiegroup/drools-wb
+    dependencies:
+      - project: kiegroup/lienzo-core
+      - project: kiegroup/kie-wb-common
+
+  - project: kiegroup/optaplanner-wb
+    dependencies:
+      - project: kiegroup/appformer
+      - project: kiegroup/kie-uberfire-extensions
+      - project: kiegroup/drools-wb
+      - project: kiegroup/drools
+      - project: kiegroup/optaplanner
+      - project: kiegroup/kie-soup
+      - project: kiegroup/kie-wb-common
+      - project: kiegroup/kie-wb-playground
+
+  - project: kiegroup/jbpm-designer
+    dependencies:
+      - project: kiegroup/kie-wb-common
+
+  - project: kiegroup/jbpm-work-items
+    dependencies:
+      - project: kiegroup/openshift-drools-hacep
+      - project: kiegroup/kie-wb-playground
+
+  - project: kiegroup/jbpm-wb
+    dependencies:
+      - project: kiegroup/kie-uberfire-extensions
+      - project: kiegroup/drools-wb
+      - project: kiegroup/jbpm-designer
+      - project: kiegroup/jbpm-work-items
+
+  - project: kiegroup/kie-docs
+
+  - project: kiegroup/optaweb-employee-rostering
+    dependencies:
+      - project: kiegroup/optaplanner
+    mapping:
+      dependencies:
+        default:
+          - source: 7.x
+            target: main
+      dependant:
+        default:
+          - source: main
+            target: 7.x
+      exclude:
+        - kiegroup/optaweb-vehicle-routing
+        - kiegroup/optaplanner
+
+  - project: kiegroup/optaweb-vehicle-routing
+    dependencies:
+      - project: kiegroup/optaplanner
+    mapping:
+      dependencies:
+        default:
+          - source: 7.x
+            target: main
+      dependant:
+        default:
+          - source: main
+            target: 7.x
+      exclude:
+        - kiegroup/optaweb-employee-rostering
+        - kiegroup/optaplanner
+
+  - project: kiegroup/kie-wb-distributions
+    dependencies:
+      - project: kiegroup/appformer
+      - project: kiegroup/kie-soup
+      - project: kiegroup/drools
+      - project: kiegroup/optaplanner
+      - project: kiegroup/jbpm
+      - project: kiegroup/kie-uberfire-extensions
+      - project: kiegroup/jbpm-wb

--- a/test/resources/schema-tests/build/archive-artifacts/correct.yml
+++ b/test/resources/schema-tests/build/archive-artifacts/correct.yml
@@ -1,0 +1,38 @@
+version: 2.1
+dependencies: http://some-dependency
+default:
+  build-command:
+    current: echo
+build:
+  - project: "owner/project"
+    build-command:
+      current: echo
+    archive-artifacts:
+      name: "archive"
+      path: |
+        hello
+        hello2
+  - project: "owner/project"
+    build-command:
+      current: echo
+    archive-artifacts:
+      name: "archive"
+      path: hello
+      dependencies: "all"
+  - project: "owner/project"
+    build-command:
+      current: echo
+    archive-artifacts:
+      name: "archive"
+      path: hello
+      dependencies: "none"
+  - project: "owner/project"
+    build-command:
+      current: echo
+    archive-artifacts:
+      name: "archive"
+      path: hello
+      dependencies:
+        - ownerA/projectA
+        - ownerB/projectB
+      

--- a/test/resources/schema-tests/build/archive-artifacts/incorrect-dependencies.yml
+++ b/test/resources/schema-tests/build/archive-artifacts/incorrect-dependencies.yml
@@ -1,0 +1,14 @@
+version: 2.1
+dependencies: http://some-dependency
+default:
+  build-command:
+    current: echo
+build:
+  - project: "owner/project"
+    build-command:
+      current: echo
+    archive-artifacts:
+      name: "archive"
+      path: hello
+      dependencies: any
+      

--- a/test/resources/schema-tests/build/archive-artifacts/incorrect-project-name.yml
+++ b/test/resources/schema-tests/build/archive-artifacts/incorrect-project-name.yml
@@ -1,0 +1,15 @@
+version: 2.1
+dependencies: http://some-dependency
+default:
+  build-command:
+    current: echo
+build:
+  - project: "owner/project"
+    build-command:
+      current: echo
+    archive-artifacts:
+      name: "archive"
+      path: hello
+      dependencies:
+        - ownerA
+      

--- a/test/resources/schema-tests/build/archive-artifacts/missing.yml
+++ b/test/resources/schema-tests/build/archive-artifacts/missing.yml
@@ -1,0 +1,12 @@
+version: 2.1
+dependencies: http://some-dependency
+default:
+  build-command:
+    current: echo
+build:
+  - project: "owner/project"
+    build-command:
+      current: echo
+    archive-artifacts:
+     
+      

--- a/test/resources/schema-tests/build/build-command/correct.yml
+++ b/test/resources/schema-tests/build/build-command/correct.yml
@@ -1,0 +1,37 @@
+version: 2.1
+dependencies: http://some-dependency
+default:
+  build-command:
+    current: echo
+build:
+  - project: owner/project
+    build-command:
+      current: echo
+  - project: owner/project
+    build-command:
+      upstream: echo
+  - project: owner/project
+    build-command:
+      downstream: echo
+  - project: owner/project
+    build-command:
+      before:
+        current: echo
+  - project: owner/project
+    build-command:
+      after:
+        upstream: echo
+  - project: owner/project
+    build-command:
+      current: |
+        echo 1
+        echo 2
+      after:
+        upstream: echo
+        downstream: |
+          echo2
+      before:
+        upstream: echo
+        downstream: echo
+        current: echo
+      upstream: echo

--- a/test/resources/schema-tests/build/build-command/missing.yml
+++ b/test/resources/schema-tests/build/build-command/missing.yml
@@ -1,0 +1,9 @@
+version: 2.1
+dependencies: http://some-dependency
+default:
+  build-command:
+    current: echo
+build:
+  - project: "owner/project"
+  - project: "owner/project"
+    build-command:

--- a/test/resources/schema-tests/build/correct.yml
+++ b/test/resources/schema-tests/build/correct.yml
@@ -1,0 +1,12 @@
+version: 2.1
+dependencies: http://some-dependency
+default:
+  build-command:
+    current: echo
+build:
+  - project: "owner/project"
+    build-command:
+      current: echo
+  - project: "owner/project"
+    build-command:
+      current: echo

--- a/test/resources/schema-tests/build/incorrect-project-name.yml
+++ b/test/resources/schema-tests/build/incorrect-project-name.yml
@@ -1,0 +1,9 @@
+version: 2.1
+dependencies: http://some-dependency
+default:
+  build-command:
+    current: echo
+build:
+  - project: "owner"
+    build-command:
+      current: echo

--- a/test/resources/schema-tests/build/incorrect-type.yml
+++ b/test/resources/schema-tests/build/incorrect-type.yml
@@ -1,0 +1,9 @@
+version: 2.1
+dependencies: http://some-dependency
+default:
+  build-command:
+    current: echo
+build:
+  project: owner/project
+  build-command:
+    current: echo

--- a/test/resources/schema-tests/default/correct.yml
+++ b/test/resources/schema-tests/default/correct.yml
@@ -1,0 +1,5 @@
+version: 2.1
+dependencies: http://some-dependency
+default:
+  build-command:
+    current: echo

--- a/test/resources/schema-tests/default/incorrect.yml
+++ b/test/resources/schema-tests/default/incorrect.yml
@@ -1,0 +1,5 @@
+version: 2.1
+dependencies: http://some-dependency
+default:
+  - build-command:
+      current: echo

--- a/test/resources/schema-tests/dependencies/correct-array.yml
+++ b/test/resources/schema-tests/dependencies/correct-array.yml
@@ -1,0 +1,10 @@
+version: 2.1
+dependencies:
+  - project: kiegroup/appformer
+  - project: owner/project
+default:
+  build-command:
+    current: echo
+    upstream: echo
+    after:
+      upstream: echo

--- a/test/resources/schema-tests/dependencies/correct-string.yml
+++ b/test/resources/schema-tests/dependencies/correct-string.yml
@@ -1,0 +1,8 @@
+version: 2.1
+dependencies: http://some-dependency
+default:
+  build-command:
+    current: echo
+    upstream: echo
+    after:
+      upstream: echo

--- a/test/resources/schema-tests/dependencies/dependencies/correct.yml
+++ b/test/resources/schema-tests/dependencies/dependencies/correct.yml
@@ -1,0 +1,12 @@
+version: 2.1
+dependencies:
+  - project: abc/def
+    dependencies:
+      - project: kie/project
+      - project: owner/project
+default:
+  build-command:
+    current: echo
+    upstream: echo
+    after:
+      upstream: echo

--- a/test/resources/schema-tests/dependencies/dependencies/incorrect.yml
+++ b/test/resources/schema-tests/dependencies/dependencies/incorrect.yml
@@ -1,0 +1,16 @@
+version: 2.1
+dependencies:
+  - project: kiegroup/appformer
+    dependencies: kie/project
+  - project: owner/project
+    dependencies:
+      project: kie/project
+  - project: abc/def
+    dependencies:
+      - project: kie
+default:
+  build-command:
+    current: echo
+    upstream: echo
+    after:
+      upstream: echo

--- a/test/resources/schema-tests/dependencies/incorrect-project-name.yml
+++ b/test/resources/schema-tests/dependencies/incorrect-project-name.yml
@@ -1,0 +1,9 @@
+version: 2.1
+dependencies:
+  - project: kiegroup
+default:
+  build-command:
+    current: echo
+    upstream: echo
+    after:
+      upstream: echo

--- a/test/resources/schema-tests/dependencies/incorrect-type.yml
+++ b/test/resources/schema-tests/dependencies/incorrect-type.yml
@@ -1,0 +1,9 @@
+version: 2.1
+dependencies:
+  project: "hello/anc"
+default:
+  build-command:
+    current: echo
+    upstream: echo
+    after:
+      upstream: echo

--- a/test/resources/schema-tests/dependencies/mapping/correct-default-exclude.yml
+++ b/test/resources/schema-tests/dependencies/mapping/correct-default-exclude.yml
@@ -1,0 +1,28 @@
+version: 2.1
+dependencies:
+  - project: kiegroup/appformer
+    mapping:
+      dependencies:
+        default:
+          - source: 7.x
+            target: main
+        owner/project:
+          - source: 8.x
+            target: main
+          - source: 6.x
+            targetExpression: expression
+      dependant:
+        default:
+          - source: 7.x
+            target: main
+        kie/project:
+          - source: 8.x
+            target: main
+          - source: 6.x
+            targetExpression: expression
+default:
+  build-command:
+    current: echo
+    upstream: echo
+    after:
+      upstream: echo

--- a/test/resources/schema-tests/dependencies/mapping/correct.yml
+++ b/test/resources/schema-tests/dependencies/mapping/correct.yml
@@ -1,0 +1,29 @@
+version: 2.1
+dependencies:
+  - project: kiegroup/appformer
+    mapping:
+      dependencies:
+        default:
+          - source: 7.x
+            target: main
+        owner/project:
+          - source: 8.x
+            target: main
+          - source: 6.x
+            targetExpression: expression
+      dependant:
+        default:
+          - source: 7.x
+            target: main
+        kie/project:
+          - source: 8.x
+            target: main
+          - source: 6.x
+            targetExpression: expression
+      exclude: ["abc/def"]
+default:
+  build-command:
+    current: echo
+    upstream: echo
+    after:
+      upstream: echo

--- a/test/resources/schema-tests/dependencies/mapping/incorrect-exclude.yml
+++ b/test/resources/schema-tests/dependencies/mapping/incorrect-exclude.yml
@@ -1,0 +1,29 @@
+version: 2.1
+dependencies:
+  - project: kiegroup/appformer
+    mapping:
+      dependencies:
+        default:
+          - source: 7.x
+            target: main
+        owner/project:
+          - source: 8.x
+            target: main
+          - source: 6.x
+            targetExpression: expression
+      dependant:
+        default:
+          - source: 7.x
+            target: main
+        kie/project:
+          - source: 8.x
+            target: main
+          - source: 6.x
+            targetExpression: expression
+      exclude: ["abc"]
+default:
+  build-command:
+    current: echo
+    upstream: echo
+    after:
+      upstream: echo

--- a/test/resources/schema-tests/dependencies/mapping/incorrect-project-name-key.yml
+++ b/test/resources/schema-tests/dependencies/mapping/incorrect-project-name-key.yml
@@ -1,0 +1,29 @@
+version: 2.1
+dependencies:
+  - project: kiegroup/appformer
+    mapping:
+      dependencies:
+        default:
+          - source: 7.x
+            target: main
+        owner:
+          - source: 8.x
+            target: main
+          - source: 6.x
+            targetExpression: expression
+      dependant:
+        default:
+          - source: 7.x
+            target: main
+        project:
+          - source: 8.x
+            target: main
+          - source: 6.x
+            targetExpression: expression
+      exclude: ["abc/def"]
+default:
+  build-command:
+    current: echo
+    upstream: echo
+    after:
+      upstream: echo

--- a/test/resources/schema-tests/dependencies/mapping/incorrect-source-to-target.yml
+++ b/test/resources/schema-tests/dependencies/mapping/incorrect-source-to-target.yml
@@ -1,0 +1,21 @@
+version: 2.1
+dependencies:
+  - project: kiegroup/appformer
+    mapping:
+      dependencies:
+        default:
+          - source: 7.x
+            target: main
+            targetExpression: expression
+      dependant:
+        default:
+          - source: 7.x
+            target: main
+            targetExpression: expression
+      exclude: ["abc/def"]
+default:
+  build-command:
+    current: echo
+    upstream: echo
+    after:
+      upstream: echo

--- a/test/resources/schema-tests/dependencies/mapping/incorrect-type.yml
+++ b/test/resources/schema-tests/dependencies/mapping/incorrect-type.yml
@@ -1,0 +1,21 @@
+version: 2.1
+dependencies:
+  - project: kiegroup/appformer
+    mapping:
+      dependencies:
+        default:
+          source: 7.x
+          target: main
+          targetExpression: expression
+      dependant:
+        default:
+          source: 7.x
+          target: main
+          targetExpression: expression
+      exclude: ["abc/def"]
+default:
+  build-command:
+    current: echo
+    upstream: echo
+    after:
+      upstream: echo

--- a/test/resources/schema-tests/dependencies/mapping/missing-default.yml
+++ b/test/resources/schema-tests/dependencies/mapping/missing-default.yml
@@ -1,0 +1,21 @@
+version: 2.1
+dependencies:
+  - project: kiegroup/appformer
+    mapping:
+      dependencies:
+        ownerA/projectA:
+          - source: 7.x
+            target: main
+            targetExpression: expression
+      dependant:
+        ownerB/projectB:
+          - source: 7.x
+            target: main
+            targetExpression: expression
+      exclude: ["abc/def"]
+default:
+  build-command:
+    current: echo
+    upstream: echo
+    after:
+      upstream: echo

--- a/test/resources/schema-tests/dependencies/mapping/missing.yml
+++ b/test/resources/schema-tests/dependencies/mapping/missing.yml
@@ -1,0 +1,11 @@
+version: 2.1
+dependencies:
+  - project: kiegroup/appformer
+    mapping:
+      exclude: ["abc/def"]
+default:
+  build-command:
+    current: echo
+    upstream: echo
+    after:
+      upstream: echo

--- a/test/resources/schema-tests/dependencies/missing.yml
+++ b/test/resources/schema-tests/dependencies/missing.yml
@@ -1,0 +1,7 @@
+version: 2.1
+default:
+  build-command:
+    current: echo
+    upstream: echo
+    after:
+      upstream: echo

--- a/test/resources/schema-tests/version/correct.yml
+++ b/test/resources/schema-tests/version/correct.yml
@@ -1,0 +1,8 @@
+version: "2.1"
+dependencies: "depend"
+default:
+  build-command:
+    current: echo
+    upstream: echo
+    after:
+      upstream: echo

--- a/test/resources/schema-tests/version/incorrect.yml
+++ b/test/resources/schema-tests/version/incorrect.yml
@@ -1,0 +1,8 @@
+version: 2.2
+dependencies: "depend"
+default:
+  build-command:
+    current: echo
+    upstream: echo
+    after:
+      upstream: echo

--- a/test/resources/schema-tests/version/missing.yml
+++ b/test/resources/schema-tests/version/missing.yml
@@ -1,0 +1,7 @@
+dependencies: "depend"
+default:
+  build-command:
+    current: echo
+    upstream: echo
+    after:
+      upstream: echo

--- a/test/util/yaml.test.ts
+++ b/test/util/yaml.test.ts
@@ -1,0 +1,374 @@
+import { loadDefinitionFile } from "@bc-cr/util/yaml";
+import { readdirSync, readFileSync } from "fs";
+import path from "path";
+const resourcePath = path.resolve(__dirname, "..", "resources", "schema-tests");
+
+describe("version validation", () => {
+  const versionPath = path.join(resourcePath, "version");
+  test.each([
+    ["no version", path.join(versionPath, "missing.yml")],
+    ["incorrect version", path.join(versionPath, "incorrect.yml")],
+  ])("%p", async (_title: string, testFile: string) => {
+    await expect(
+      loadDefinitionFile(readFileSync(testFile, "utf8"))
+    ).rejects.toThrowError();
+  });
+
+  test("correct version", async () => {
+    await expect(
+      loadDefinitionFile(
+        readFileSync(path.join(versionPath, "correct.yml"), "utf8")
+      )
+    ).resolves.toMatchObject({ version: "2.1" });
+  });
+});
+
+describe("dependencies validation", () => {
+  const dependenciesPath = path.join(resourcePath, "dependencies");
+  test.each([
+    ["no dependencies", path.join(dependenciesPath, "missing.yml")],
+    [
+      "incorrect dependencies: not a string or an array",
+      path.join(dependenciesPath, "incorrect-type.yml"),
+    ],
+    [
+      "incorrect dependencies: invalid project name",
+      path.join(dependenciesPath, "incorrect-project-name.yml"),
+    ],
+  ])("%p", async (_title: string, testFile: string) => {
+    await expect(
+      loadDefinitionFile(readFileSync(testFile, "utf8"))
+    ).rejects.toThrowError();
+  });
+
+  test.each([
+    [
+      "correct dependencies: array",
+      path.join(dependenciesPath, "correct-array.yml"),
+      {
+        dependencies: [
+          {
+            project: "kiegroup/appformer",
+          },
+          {
+            project: "owner/project",
+          },
+        ],
+      },
+    ],
+    [
+      "correct dependencies: string",
+      path.join(dependenciesPath, "correct-string.yml"),
+      {
+        dependencies: "http://some-dependency",
+      },
+    ],
+  ])(
+    "%p",
+    async (
+      _title: string,
+      testFile: string,
+      expected: Record<string, unknown>
+    ) => {
+      await expect(
+        loadDefinitionFile(readFileSync(testFile, "utf8"))
+      ).resolves.toMatchObject(expected);
+    }
+  );
+});
+
+describe("default validation", () => {
+  const defaultPath = path.join(resourcePath, "default");
+  test("incorrect default: not an object", async () => {
+    await expect(
+      loadDefinitionFile(readFileSync(path.join(defaultPath, "incorrect.yml"), "utf8"))
+    ).rejects.toThrowError();
+  });
+
+  test("correct default", async () => {
+    await expect(
+      loadDefinitionFile(
+        readFileSync(path.join(defaultPath, "correct.yml"), "utf8")
+      )
+    ).resolves.toMatchObject({
+      default: {
+        "build-command": {
+          current: ["echo"],
+        },
+      },
+    });
+  });
+});
+
+describe("dependencies.dependencies validation", () => {
+  const dependenciesPath = path.join(
+    resourcePath,
+    "dependencies",
+    "dependencies"
+  );
+
+  test("incorrect dependencies.dependencies", async () => {
+    await expect(
+      loadDefinitionFile(
+        readFileSync(path.join(dependenciesPath, "incorrect.yml"), "utf8")
+      )
+    ).rejects.toThrowError();
+  });
+
+  test("correct dependencies.dependencies", async () => {
+    await expect(
+      loadDefinitionFile(
+        readFileSync(path.join(dependenciesPath, "correct.yml"), "utf8")
+      )
+    ).resolves.toMatchObject({
+      dependencies: [
+        {
+          project: "abc/def",
+          dependencies: [
+            {
+              project: "kie/project",
+            },
+            {
+              project: "owner/project",
+            },
+          ],
+        },
+      ],
+    });
+  });
+});
+
+describe("dependencies.mapping validation", () => {
+  const mappingPath = path.join(resourcePath, "dependencies", "mapping");
+  test.each([
+    ["no dependencies and dependant", path.join(mappingPath, "missing.yml")],
+    ["no default", path.join(mappingPath, "missing-default.yml")],
+    [
+      "incorrect source and target",
+      path.join(mappingPath, "incorrect-source-to-target.yml"),
+    ],
+    [
+      "incorrect project name as key",
+      path.join(mappingPath, "incorrect-project-name-key.yml"),
+    ],
+    [
+      "incorrect dependency/dependant type",
+      path.join(mappingPath, "incorrect-type.yml"),
+    ],
+    ["incorrect exclude", path.join(mappingPath, "incorrect-exclude.yml")],
+  ])("%p", async (_title: string, testFile: string) => {
+    await expect(
+      loadDefinitionFile(readFileSync(testFile, "utf8"))
+    ).rejects.toThrowError();
+  });
+
+  test.each([
+    [
+      "correct using default exclude",
+      path.join(mappingPath, "correct-default-exclude.yml"),
+      [],
+    ],
+    ["correct", path.join(mappingPath, "correct.yml"), ["abc/def"]],
+  ])(
+    "%p",
+    async (_title: string, testFile: string, expectedExclude: string[]) => {
+      await expect(
+        loadDefinitionFile(readFileSync(testFile, "utf8"))
+      ).resolves.toMatchObject({
+        dependencies: [
+          {
+            project: "kiegroup/appformer",
+            mapping: {
+              dependencies: {
+                default: [{ source: "7.x", target: "main" }],
+                "owner/project": [
+                  { source: "8.x", target: "main" },
+                  { source: "6.x", targetExpression: "expression" },
+                ],
+              },
+              dependant: {
+                default: [{ source: "7.x", target: "main" }],
+                "kie/project": [
+                  { source: "8.x", target: "main" },
+                  { source: "6.x", targetExpression: "expression" },
+                ],
+              },
+              exclude: expectedExclude,
+            },
+          },
+        ],
+      });
+    }
+  );
+});
+
+describe("build", () => {
+  const buildPath = path.join(resourcePath, "build");
+  test.each([
+    [
+      "incorrect type: not an array",
+      path.join(buildPath, "incorrect-type.yml"),
+    ],
+    [
+      "incorrect project name",
+      path.join(buildPath, "incorrect-project-name.yml"),
+    ],
+  ])("%p", async (_title: string, testFile: string) => {
+    await expect(
+      loadDefinitionFile(readFileSync(testFile, "utf8"))
+    ).rejects.toThrowError();
+  });
+
+  test("correct", async () => {
+    await expect(
+      loadDefinitionFile(
+        readFileSync(path.join(buildPath, "correct.yml"), "utf8")
+      )
+    ).resolves.toMatchObject({
+      build: [
+        {
+          project: "owner/project",
+          "build-command": { current: ["echo"] },
+        },
+        {
+          project: "owner/project",
+          "build-command": { current: ["echo"] },
+        },
+      ],
+    });
+  });
+});
+
+describe("build.build-command", () => {
+  const buildCommandPath = path.join(resourcePath, "build", "build-command");
+
+  test("missing build-command and missing all of the keys in build-command", async () => {
+    await expect(
+      loadDefinitionFile(
+        readFileSync(path.join(buildCommandPath, "missing.yml"), "utf8")
+      )
+    ).rejects.toThrowError();
+  });
+
+  test("correct build-command", async () => {
+    await expect(
+      loadDefinitionFile(
+        readFileSync(path.join(buildCommandPath, "correct.yml"), "utf8")
+      )
+    ).resolves.toMatchObject({
+      build: [
+        { project: "owner/project", "build-command": { current: ["echo"] } },
+        { project: "owner/project", "build-command": { upstream: ["echo"] } },
+        { project: "owner/project", "build-command": { downstream: ["echo"] } },
+        {
+          project: "owner/project",
+          "build-command": { before: { current: ["echo"] } },
+        },
+        {
+          project: "owner/project",
+          "build-command": { after: { upstream: ["echo"] } },
+        },
+        {
+          project: "owner/project",
+          "build-command": {
+            current: ["echo 1", "echo 2"],
+            after: { upstream: ["echo"], downstream: ["echo2"] },
+            before: {
+              upstream: ["echo"],
+              downstream: ["echo"],
+              current: ["echo"],
+            },
+            upstream: ["echo"],
+          },
+        },
+      ],
+    });
+  });
+});
+
+describe("build.archive-artifacts", () => {
+  const archiveArtifactsPath = path.join(
+    resourcePath,
+    "build",
+    "archive-artifacts"
+  );
+
+  test.each([
+    ["missing keys", path.join(archiveArtifactsPath, "missing.yml")],
+    [
+      "incorrect project name",
+      path.join(archiveArtifactsPath, "incorrect-project-name.yml"),
+    ],
+    [
+      "incorrect dependencies",
+      path.join(archiveArtifactsPath, "incorrect-dependencies.yml"),
+    ],
+  ])("%p", async (_title: string, testFile: string) => {
+    await expect(
+      loadDefinitionFile(readFileSync(testFile, "utf8"))
+    ).rejects.toThrowError();
+  });
+
+  test("correct archive-artifacts", async () => {
+    await expect(
+      loadDefinitionFile(
+        readFileSync(path.join(archiveArtifactsPath, "correct.yml"), "utf8")
+      )
+    ).resolves.toMatchObject({
+      build: [
+        {
+          project: "owner/project",
+          "build-command": { current: ["echo"] },
+          "archive-artifacts": {
+            name: "archive",
+            path: ["hello", "hello2"],
+            dependencies: "none",
+          },
+        },
+        {
+          project: "owner/project",
+          "build-command": { current: ["echo"] },
+          "archive-artifacts": {
+            name: "archive",
+            path: ["hello"],
+            dependencies: "all",
+          },
+        },
+        {
+          project: "owner/project",
+          "build-command": { current: ["echo"] },
+          "archive-artifacts": {
+            name: "archive",
+            path: ["hello"],
+            dependencies: "none",
+          },
+        },
+        {
+          project: "owner/project",
+          "build-command": { current: ["echo"] },
+          "archive-artifacts": {
+            name: "archive",
+            path: ["hello"],
+            dependencies: ["ownerA/projectA", "ownerB/projectB"],
+          },
+        },
+      ],
+    });
+  });
+});
+
+describe("works for definition file examples from older versions", () => {
+  const backportPath = path.join(resourcePath, "backport");
+  test("correct", async () => {
+    const files = readdirSync(backportPath);
+    await Promise.all(
+      files.map(file =>
+        expect(
+          loadDefinitionFile(
+            readFileSync(path.join(backportPath, file), "utf8")
+          )
+        ).resolves.not.toThrowError()
+      )
+    );
+  });
+});


### PR DESCRIPTION
Instead of writing functions to manually validate yaml, I used ajv which automatically lets us validate a json against a schema.
So using a yaml parser we will first convert the yaml to json and then validate that json against our schema. 

This also allows us to freely make changes to the definition file fields without having to worry of validating it by simply making changes to the schema.

This also added more fine tuned and accurate validation than in the [previous version](https://github.com/kiegroup/build-chain-configuration-reader/blob/main/src/lib/util/validations.js)

(PS: The PR says 50 files changed but that's mainly because I added a lot of test definition files to cover edge cases as well as make sure that its compatible with existing definition files. To make reviewing easy you can filter out the last commit which pushes the test definition files)
