### PR TITLE
Types to schema

### DIFF
--- a/src/domain/archive-artifacts.ts
+++ b/src/domain/archive-artifacts.ts
@@ -1,25 +1,9 @@
-export enum ArchiveOn {
-  SUCCESS = "success",
-  FAILURE = "failure",
-}
-
-export enum IfNoFilesFound {
-  WARN = "warn",
-  ERROR = "error",
-  IGNORE = "ignore",
-}
-
-export enum ArchiveDependencies {
-  ALL = "all",
-  NONE = "none",
-}
-
-export type ArchiveArtifacts = {
-  "if-no-files-found"?: IfNoFilesFound;
-  dependencies?: string[] | ArchiveDependencies;
-  name: string;
+export interface ArchiveArtifacts {
+  name?: string;
+  "if-no-files-found": "warn" | "error" | "ignore";
+  dependencies: string[] | "all" | "none";
   paths: {
-    path?: string;
-    on?: ArchiveOn;
+    path: string;
+    on: "success" | "failure";
   }[];
-};
+}

--- a/src/domain/build.ts
+++ b/src/domain/build.ts
@@ -1,0 +1,23 @@
+import { ArchiveArtifacts } from "@bc-cr/domain/archive-artifacts";
+
+export type Command = string[];
+
+export interface CommandLevel {
+  current: Command
+  upstream: Command,
+  downstream: Command
+}
+
+export interface BuildCommand {
+  before?: CommandLevel,
+  after?: CommandLevel,
+  current: Command,
+  upstream: Command,
+  downstream: Command
+}
+
+export interface Build {
+  project: string,
+  "build-command"?: BuildCommand,
+  "archive-artifacts"?: ArchiveArtifacts
+}

--- a/src/domain/commands.ts
+++ b/src/domain/commands.ts
@@ -1,5 +1,0 @@
-export type Commands = {
-  upstream: string[];
-  current: string[];
-  downstream: string[];
-}

--- a/src/domain/definition-file.ts
+++ b/src/domain/definition-file.ts
@@ -1,0 +1,17 @@
+import { Build, BuildCommand } from "@bc-cr/domain/build";
+import { Dependency } from "@bc-cr/domain/dependencies";
+import { Mapping } from "@bc-cr/domain/mapping";
+
+export interface DefinitionFile {
+  version: "2.1" | 2.1
+  dependencies: string | {
+    project: string;
+    dependencies?: Dependency[];
+    mapping?: Mapping
+  }[]
+  extends?: string;
+  default?: {
+    "build-command": BuildCommand
+  }
+  build?: Build[]
+}

--- a/src/domain/dependencies.ts
+++ b/src/domain/dependencies.ts
@@ -1,0 +1,3 @@
+export interface Dependency {
+  project: string
+}

--- a/src/domain/mapping.ts
+++ b/src/domain/mapping.ts
@@ -1,17 +1,16 @@
-export type Mapping = {
-  source: string;
-  target: string;
-  targetExpression?: string;
-};
+export interface SourceToTarget {
+  source: string,
+  target?: string,
+  targetExpression?: string
+}
 
-export type Dependencies = { default: Mapping[] } & {
-  [key: string]: Mapping[];
-};
+export interface Depend {
+  default: SourceToTarget[],
+  [project: string]: SourceToTarget[]
+}
 
-export type Dependant = Dependencies;
-
-export type Mappings = {
-  exclude: string[];
-  dependencies: Dependencies
-  dependant: Dependant
-};
+export interface Mapping {
+  dependencies?: Depend,
+  dependant?: Depend,
+  exclude: string[]
+}

--- a/src/domain/node.ts
+++ b/src/domain/node.ts
@@ -1,5 +1,5 @@
 import { ArchiveArtifacts } from "@bc-cr/domain/archive-artifacts";
-import { Commands } from "@bc-cr/domain/commands";
+import { CommandLevel } from "@bc-cr/domain/build";
 import { Mapping } from "@bc-cr/domain/mapping";
 
 export interface Node {
@@ -7,9 +7,9 @@ export interface Node {
   parents?: Node[];
   children?: Node[];
   dependencies?: Node[];
-  before?: Commands;
-  commands?: Commands;
-  after?: Commands;
+  before?: CommandLevel;
+  commands?: CommandLevel;
+  after?: CommandLevel;
   mapping?: Mapping;
   clone?: string[];
   archiveArtifacts?: ArchiveArtifacts;

--- a/src/schema/archive-artifacts.ts
+++ b/src/schema/archive-artifacts.ts
@@ -1,28 +1,39 @@
+import { ArchiveArtifacts } from "@bc-cr/domain/archive-artifacts";
 import { ProjectNameSchema } from "@bc-cr/schema/project-name";
+import { JSONSchemaType } from "ajv";
 
-export const ArchiveArtifactSchema = {
-  type: "object", 
+export const ArchiveArtifactSchema: JSONSchemaType<ArchiveArtifacts> = {
+  type: "object",
   properties: {
-    name: {type: "string"},
-    path: {
+    name: { type: "string", nullable: true },
+    paths: {
       type: "array",
-      items: {type: "string"}
+      items: {
+        type: "object",
+        properties: {
+          path: { type: "string" },
+          on: { type: "string", enum: ["success", "failure"] },
+        },
+        required: ["on", "path"]
+      },
     },
     "if-no-files-found": {
+      type: "string",
       enum: ["warn", "ignore", "error"],
-      default: "warn"
+      default: "warn",
     },
     dependencies: {
       oneOf: [
         {
-          enum: ["all", "none"]
+          type: "string",
+          enum: ["all", "none"],
         },
         {
           type: "array",
-          items: ProjectNameSchema
-        }
-      ]
-    }
+          items: ProjectNameSchema,
+        },
+      ],
+    },
   },
-  required: ["path", "if-no-files-found", "dependencies"]
+  required: ["paths", "if-no-files-found", "dependencies"],
 };

--- a/src/schema/build.ts
+++ b/src/schema/build.ts
@@ -1,53 +1,45 @@
+import { Build, BuildCommand, Command, CommandLevel } from "@bc-cr/domain/build";
 import { ArchiveArtifactSchema } from "@bc-cr/schema/archive-artifacts";
 import { ProjectNameSchema } from "@bc-cr/schema/project-name";
+import { JSONSchemaType } from "ajv";
 
-const CommandSchema = {
+const CommandSchema: JSONSchemaType<Command> = {
   type: "array",
   items: {
     type: "string",
   },
 };
 
-const CommandLevelSchema = {
+const CommandLevelSchema: JSONSchemaType<CommandLevel> = {
   type: "object",
   properties: {
     current: CommandSchema,
     upstream: CommandSchema,
     downstream: CommandSchema,
   },
-  anyOf: [
-    { required: ["current"] },
-    { required: ["upstream"] },
-    { required: ["downstream"] },
-  ],
+  required: ["current", "upstream", "downstream"],
   additionalProperties: false,
 };
 
-export const BuildCommandSchema = {
+export const BuildCommandSchema: JSONSchemaType<BuildCommand> = {
   type: "object",
   properties: {
-    before: CommandLevelSchema,
-    after: CommandLevelSchema,
+    before: {...CommandLevelSchema, nullable: true},
+    after: {...CommandLevelSchema, nullable: true},
     current: CommandSchema,
     upstream: CommandSchema,
     downstream: CommandSchema,
   },
-  anyOf: [
-    { required: ["before"] },
-    { required: ["after"] },
-    { required: ["current"] },
-    { required: ["upstream"] },
-    { required: ["downstream"] },
-  ],
+  required: ["current", "upstream", "downstream"],
   additionalProperties: false,
 };
 
-export const BuildSchema = {
+export const BuildSchema: JSONSchemaType<Build> = {
   type: "object",
   properties: {
     project: ProjectNameSchema,
-    "build-command": BuildCommandSchema,
-    "archive-artifacts": ArchiveArtifactSchema
+    "build-command": {...BuildCommandSchema, nullable:  true},
+    "archive-artifacts": {...ArchiveArtifactSchema, nullable: true}
   },
   required: ["project"],
   anyOf: [

--- a/src/schema/definition-file.ts
+++ b/src/schema/definition-file.ts
@@ -1,13 +1,16 @@
+import { DefinitionFile } from "@bc-cr/domain/definition-file";
 import { BuildCommandSchema, BuildSchema } from "@bc-cr/schema/build";
 import { DependenciesSchema } from "@bc-cr/schema/dependencies";
 import { MappingSchema } from "@bc-cr/schema/mapping";
 import { ProjectNameSchema } from "@bc-cr/schema/project-name";
+import { JSONSchemaType } from "ajv";
 
-export const DefintionFileSchema = {
+export const DefintionFileSchema: JSONSchemaType<DefinitionFile> = {
   type: "object",
   properties: {
-    version: { enum: ["2.1", 2.1] },
+    version: { type: ["string", "number"], enum: ["2.1", 2.1] },
     dependencies: {
+      type: ["string", "array"],
       oneOf: [
         { type: "string" },
         {
@@ -16,8 +19,8 @@ export const DefintionFileSchema = {
             type: "object",
             properties: {
               project: ProjectNameSchema,
-              dependencies: DependenciesSchema,
-              mapping: MappingSchema,
+              dependencies: {...DependenciesSchema, nullable: true},
+              mapping: {...MappingSchema, nullable: true},
             },
             required: ["project"],
             additionalProperties: false,
@@ -27,6 +30,7 @@ export const DefintionFileSchema = {
     },
     extends: {
       type: "string",
+      nullable: true
     },
     default: {
       type: "object",
@@ -34,11 +38,13 @@ export const DefintionFileSchema = {
         "build-command": BuildCommandSchema,
       },
       required: ["build-command"],
+      nullable: true,
       additionalProperties: false,
     },
     build: {
       type: "array",
       items: BuildSchema,
+      nullable: true
     },
   },
   required: ["version", "dependencies"],

--- a/src/schema/dependencies.ts
+++ b/src/schema/dependencies.ts
@@ -1,6 +1,8 @@
+import { Dependency } from "@bc-cr/domain/dependencies";
 import { ProjectNameSchema } from "@bc-cr/schema/project-name";
+import { JSONSchemaType } from "ajv";
 
-export const DependenciesSchema = {
+export const DependenciesSchema: JSONSchemaType<Dependency[]> = {
   type: "array",
   items: {
     type: "object",

--- a/src/schema/mapping.ts
+++ b/src/schema/mapping.ts
@@ -1,11 +1,13 @@
+import { Depend, Mapping, SourceToTarget } from "@bc-cr/domain/mapping";
 import { ProjectNameSchema } from "@bc-cr/schema/project-name";
+import { JSONSchemaType } from "ajv";
 
-const SourceToTargetSchema = {
+const SourceToTargetSchema: JSONSchemaType<SourceToTarget> = {
   type: "object",
   properties: {
     source: { type: "string" },
-    target: { type: "string" },
-    targetExpression: { type: "string" },
+    target: { type: "string", nullable: true },
+    targetExpression: { type: "string", nullable: true },
   },
   required: ["source"],
   oneOf: [
@@ -19,7 +21,7 @@ const SourceToTargetSchema = {
   additionalProperties: false
 };
 
-const DependSchema = {
+const DependSchema: JSONSchemaType<Depend> = {
   type: "object",
   properties: {
     default: {
@@ -37,11 +39,11 @@ const DependSchema = {
   additionalProperties: false
 };
 
-export const MappingSchema = {
+export const MappingSchema: JSONSchemaType<Mapping> = {
   type: "object",
   properties: {
-    dependencies: DependSchema,
-    dependant: DependSchema,
+    dependencies: {...DependSchema, nullable: true},
+    dependant: {...DependSchema, nullable: true},
     exclude: {
       type: "array",
       items: ProjectNameSchema,

--- a/src/schema/project-name.ts
+++ b/src/schema/project-name.ts
@@ -1,4 +1,6 @@
-export const ProjectNameSchema = {
+import { JSONSchemaType } from "ajv";
+
+export const ProjectNameSchema: JSONSchemaType<string> = {
   type: "string",
   pattern: "^[^/]+/[^/]+$",
 };

--- a/src/util/yaml.ts
+++ b/src/util/yaml.ts
@@ -1,64 +1,155 @@
 import { parse } from "yaml";
 import Ajv from "ajv";
-import { DefintionFileSchema } from "@bc-cr/schema/definition-file-schema";
+import { DefintionFileSchema } from "@bc-cr/schema/definition-file";
 
-export async function loadDefinitionFile(content: string) {
+/**
+ * Reads yaml and validates it against the schema
+ * @param content 
+ * @returns 
+ */
+export async function validateDefinitionFile(content: string) {
   // parse yaml and perform some transformation on the raw json produced
-  const rawJSON = parse(content, (key: unknown, value: unknown) => {
-    // for all the below keys, if the value is a string, split it at "\n" and convert to array
-    const keys = ["path", "current", "upstream", "downstream"];
-    if (keys.includes(key as string) && typeof value === "string") {
-      return value.trim().split("\n");
-    }
-
-    if (key === "mapping") {
-      const val = value as Record<string, Record<string, unknown>>;
-      // if exclude is not defined in mapping then add an empty array
-      if (!val["exclude"]) {
-        return {
-          ...val,
-          exclude: [],
-        };
-      }
-      // if dependencies.default is not defined in mapping then add an empty array
-      if (val["dependencies"] && !val["dependencies"]["default"]) {
-        return {
-          ...val,
-          dependencies: {
-            ...val["dependencies"],
-            default: [],
-          },
-        };
-      }
-      // if dependant.default is not defined in mapping then add an empty array
-      if (val["dependant"] && !val["dependant"]["default"]) {
-        return {
-          ...val,
-          dependant: {
-            ...val["dependant"],
-            default: [],
-          },
-        };
-      }
-    }
-    if (key === "archive-artifacts") {
-      const val = value as Record<string, unknown>;
-      // if dependencies is not defined in archive-artifacts then use none by default
-      if (!val["dependencies"]) {
-        return {
-          ...val,
-          dependencies: "none",
-        };
-      }
-    }
-    return value;
-  });
-  const ajv = new Ajv({ useDefaults: "empty" });
+  const rawJSON = parse(content, reviver);
+  const ajv = new Ajv({ useDefaults: "empty", allowUnionTypes: true });
   const validate = ajv.compile(DefintionFileSchema);
   const valid = validate(rawJSON);
   if (valid) {
     return rawJSON;
   } else {
     throw new Error(JSON.stringify(validate.errors));
+  }
+}
+
+/**
+ * A reviver function to transform json keys
+ * @param key 
+ * @param value 
+ * @returns 
+ */
+function reviver(key: unknown, value: unknown) {
+  let result;
+
+  if ((result = convertToArray(key, value))) {
+    return result;
+  }
+
+  if ((result = parseMapping(key, value))) {
+    return result;
+  }
+
+  if ((result = parseBuild(key, value))) {
+    return result;
+  }
+
+  if ((result = parseArchiveArtifacts(key, value))) {
+    return result;
+  }
+
+  return value;
+}
+
+/**
+ * Converts a string to an array of string
+ * @param key 
+ * @param value 
+ * @returns 
+ */
+function convertToArray(key: unknown, value: unknown) {
+  // for all the below keys, if the value is a string, split it at "\n" and convert to array
+  if (
+    ["path", "current", "upstream", "downstream"].includes(key as string) &&
+    typeof value === "string"
+  ) {
+    return value.trim().split("\n");
+  }
+}
+
+/**
+ * If the given key is not present in the value then initialize it with init
+ * @param key 
+ * @param value 
+ * @param init 
+ * @returns 
+ */
+function initializeUndefined(
+  key: string,
+  value: Record<string, unknown>,
+  init: unknown
+) {
+  if (!value[key]) {
+    value[key] = init;
+  }
+  return value;
+}
+
+/**
+ * Parse the mapping section of definition file
+ * @param key 
+ * @param value 
+ * @returns 
+ */
+function parseMapping(key: unknown, value: unknown) {
+  if (key === "mapping") {
+    const val = value as Record<string, Record<string, unknown>>;
+    // if exclude is not defined in mapping then add an empty array
+    initializeUndefined("exclude", val, []);
+
+    // if dependencies.default is not defined in mapping then add an empty array
+    if (val["dependencies"]) {
+      initializeUndefined("default", val["dependencies"], []);
+    }
+
+    // if dependant.default is not defined in mapping then add an empty array
+    if (val["dependant"]) {
+      initializeUndefined("default", val["dependant"], []);
+    }
+    return val;
+  }
+}
+
+/**
+ * Parse the build-command section of the definition file
+ * @param key 
+ * @param value 
+ * @returns 
+ */
+function parseBuild(key: unknown, value: unknown) {
+  // for any of the keys below, if they don't contain "upstream", "current" or "downstream" keys then initialize them to an empty array
+  if (["before", "after", "build-command"].includes(key as string)) {
+    const val = value as Record<string, unknown>;
+    ["upstream", "downstream", "current"].forEach(k => {
+      initializeUndefined(k, val, []);
+    });
+    return val;
+  }
+}
+
+/**
+ * Parse the archive artifacts section of the definition file
+ * @param key 
+ * @param value 
+ * @returns 
+ */
+function parseArchiveArtifacts(key: unknown, value: unknown) {
+  if (key === "archive-artifacts") {
+    const val = value as Record<string, unknown>;
+    // if dependencies is not defined in archive-artifacts then use none by default
+    initializeUndefined("dependencies", val, "none");
+
+    // transform array of path to array of path and on (on determines when the artifact is to be uploaded)
+    if (val["path"] && Array.isArray(val["path"])) {
+      val["paths"] = val.path.map(p => {
+        if (typeof p === "string") {
+          const index = p.lastIndexOf("@");
+          return {
+            path: index === -1 ? p : p.slice(0, index),
+            on: index === -1 ? "success" : p.slice(index),
+          };
+        }
+      });
+      delete val["path"];
+    }
+
+    return val;
   }
 }


### PR DESCRIPTION
Resolves #49 

Turns out in AJV we can write schema as type of `JSONSchema` and pass a generic type to it. This creates a relation between types and schemas and we are able to keep them consistent. 

This PR connects domain objects together with schema