### PR TITLE
Project tree

### DIFF
--- a/src/domain/dependencies.ts
+++ b/src/domain/dependencies.ts
@@ -2,6 +2,7 @@ import { Mapping } from "@bc-cr/domain/mapping";
 
 export interface Dependency {
   project: string;
+  clone?: string[];
   dependencies?: {
     project: string
   }[];

--- a/src/domain/node.ts
+++ b/src/domain/node.ts
@@ -4,9 +4,8 @@ import { Mapping } from "@bc-cr/domain/mapping";
 
 export interface Node {
   project: string;
-  parents?: Node[];
-  children?: Node[];
-  dependencies?: Node[];
+  parents: Node[];
+  children: Node[];
   before?: CommandLevel;
   commands?: CommandLevel;
   after?: CommandLevel;

--- a/src/domain/readerOptions.ts
+++ b/src/domain/readerOptions.ts
@@ -1,0 +1,6 @@
+export type ReaderOpts = {
+  token?: string,
+  group?: string,
+  name?: string,
+  branch?: string
+}

--- a/src/schema/dependencies.ts
+++ b/src/schema/dependencies.ts
@@ -14,14 +14,15 @@ export const DependenciesSchema: JSONSchemaType<Dependency[]> = {
         items: {
           type: "object",
           properties: {
-            project: {type: "string"}
+            project: { type: "string" },
           },
           required: ["project"],
-          additionalProperties: false
+          additionalProperties: false,
         },
-        nullable: true
+        nullable: true,
       },
-      mapping: {...MappingSchema, nullable: true}
+      mapping: { ...MappingSchema, nullable: true },
+      clone: { type: "array", items: { type: "string" }, nullable: true },
     },
     required: ["project"],
     additionalProperties: false,

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -1,0 +1,48 @@
+import { Dependency } from "@bc-cr/domain/dependencies";
+import { Node } from "@bc-cr/domain/node";
+import { ReaderOpts } from "@bc-cr/domain/readerOptions";
+import { readDefinitionFile } from "@bc-cr/reader";
+import { constructTree } from "@bc-cr/util/construct-tree";
+
+export async function getTree(
+  definitionFileLocation: string,
+  opts?: ReaderOpts
+): Promise<Node[]> {
+  const definitionFile = await readDefinitionFile(definitionFileLocation, opts);
+  return constructTree(
+    definitionFile.dependencies as Dependency[], // readDefinitionFile ensures this is true but we need this so ts does not complain
+    definitionFile.default?.["build-command"],
+    definitionFile.build
+  );
+}
+
+export async function getTreeForProject(
+  definitionFileLocation: string,
+  project: string,
+  opts?: ReaderOpts
+): Promise<Node | undefined> {
+  const tree = await getTree(definitionFileLocation, opts);
+  return lookForProject(tree, project);
+}
+
+export function parentChainFromNode(node: Node): Node[] {
+  const result = node.parents.reduce((parents: Node[], parent: Node) => {
+    parents.push(
+      ...parentChainFromNode(parent).filter(
+        p => !parents.find(e => p.project === e.project)
+      )
+    );
+    return parents;
+  }, []);
+  result.push(node);
+  return result;
+}
+
+function lookForProject(tree: Node[], project: string): Node | undefined {
+  return (
+    tree.find(node => node.project === project) ??
+    tree
+      .map(node => lookForProject(node.children, project))
+      .find(node => !!node)
+  );
+}

--- a/src/util/construct-tree.ts
+++ b/src/util/construct-tree.ts
@@ -1,0 +1,141 @@
+import { Dependency } from "@bc-cr/domain/dependencies";
+import { Build, BuildCommand, CommandLevel } from "@bc-cr/domain/build";
+import { Node } from "@bc-cr/domain/node";
+
+export function constructTree(
+  dependencies: Dependency[],
+  defaultBuild?: BuildCommand,
+  build?: Build[]
+): Node[] {
+  // construct a map where key is the project name and value is the constructed node
+  // we are using a map for faster lookup
+  const map = dependencies.reduce((map: Record<string, Node>, dependency) => {
+    map[dependency.project] = constructNode(dependency, defaultBuild, build);
+    return map;
+  }, {});
+
+  return dependencies.reduce((roots: Node[], dependency) => {
+    if (isRoot(dependency)) {
+      // is dependency does not have any parents then it is a root and
+      // store it in the roots array
+      roots.push(map[dependency.project]);
+    } else {
+      dependency.dependencies?.forEach(parentDependency => {
+        // make sure the parent project has been defined
+        if (!map[parentDependency.project]) {
+          throw new Error(
+            `The project ${parentDependency.project} does not exist on project list. Please review your project definition file`
+          );
+        }
+
+        // add current dependency as child of the parentDependency
+        map[parentDependency.project].children.push(map[dependency.project]);
+
+        // store a reference of the parent in the child as well
+        // using a string instead of Node to avoid circular dependency
+        map[dependency.project].parents.push(map[parentDependency.project]);
+      });
+    }
+    // roots array contains nodes which don't have any parents
+    // and are the "starting" point in the tree
+    return roots;
+  }, []);
+}
+
+function constructNode(
+  dependency: Dependency,
+  defaultBuild?: BuildCommand,
+  build?: Build[]
+) {
+  const buildCommand = getBuildCommand(dependency.project, defaultBuild, build);
+  return {
+    project: dependency.project,
+    parents: [],
+    children: [],
+    archiveArtifacts: getArchiveArtifacts(dependency.project, build),
+    mapping: dependency.mapping,
+    clone: dependency.clone,
+    before: buildCommand?.before,
+    after: buildCommand?.after,
+    commands: {
+      upstream: buildCommand?.upstream ?? [],
+      downstream: buildCommand?.downstream ?? [],
+      current: buildCommand?.current ?? [],
+    },
+  };
+}
+
+function isRoot(dependency: Dependency): boolean {
+  return !dependency.dependencies || dependency.dependencies.length === 0;
+}
+
+function getArchiveArtifacts(project: string, builds?: Build[]) {
+  return builds?.find(build => build.project === project)?.[
+    "archive-artifacts"
+  ];
+}
+
+/**
+ * Given a project get the build commands for it. It uses the 
+ * default build config to fill out any missing commands
+ * @param project 
+ * @param defaultBuild 
+ * @param build 
+ * @returns 
+ */
+function getBuildCommand(
+  project: string,
+  defaultBuild?: BuildCommand,
+  build?: Build[]
+): BuildCommand | undefined {
+  const projectBuild = build?.find(b => b.project === project);
+  const buildCommand = projectBuild?.["build-command"];
+  if (!buildCommand) {
+    return defaultBuild;
+  }
+
+  return {
+    ...buildCommand,
+    after: buildCommand?.after
+      ? getDefaultCommandLevel(buildCommand.after, defaultBuild?.after)
+      : defaultBuild?.after,
+    before: buildCommand?.before
+      ? getDefaultCommandLevel(buildCommand.before, defaultBuild?.before)
+      : defaultBuild?.before,
+    ...getDefaultCommandLevel(
+      {
+        current: buildCommand.current,
+        upstream: buildCommand.upstream,
+        downstream: buildCommand.downstream,
+      },
+      defaultBuild
+    ),
+  };
+}
+
+/**
+ * Update the given commands for upstream, downstream and current with the default ones
+ * in case they are missing
+ * @param commandLevel
+ * @param defaultcommandLevel
+ * @returns
+ */
+function getDefaultCommandLevel(
+  commandLevel: CommandLevel,
+  defaultcommandLevel?: CommandLevel
+) {
+  if (!defaultcommandLevel) {
+    return commandLevel;
+  }
+
+  const commandLevelClone = { ...commandLevel };
+
+  Object.entries(commandLevel).forEach(([key, val]) => {
+    if (val.length === 0) {
+      commandLevelClone[key as keyof CommandLevel] =
+        defaultcommandLevel[key as keyof CommandLevel] ?? val;
+    }
+  });
+
+  return commandLevelClone;
+}

--- a/src/util/yaml.ts
+++ b/src/util/yaml.ts
@@ -45,7 +45,9 @@ function reviver(key: unknown, value: unknown) {
 function convertToArray(key: unknown, value: unknown) {
   // for all the below keys, if the value is a string, split it at "\n" and convert to array
   if (
-    ["path", "current", "upstream", "downstream"].includes(key as string) &&
+    ["path", "current", "upstream", "downstream", "clone"].includes(
+      key as string
+    ) &&
     typeof value === "string"
   ) {
     return value.trim().split("\n");

--- a/test/reader.test.ts
+++ b/test/reader.test.ts
@@ -27,7 +27,7 @@ describe("get content", () => {
       .replyWithFile(200, path.join(resourcePath, "content.yml"));
     const definitionFile = await readDefinitionFile(
       "https://definitionfile.com/content.yml",
-      token
+      { token }
     );
     expect(definitionFile).toStrictEqual({
       version: "2.1",

--- a/test/resources/construct-tree/build-with-default.yml
+++ b/test/resources/construct-tree/build-with-default.yml
@@ -1,0 +1,35 @@
+version: "2.1"
+
+dependencies:
+  - project: kiegroup/lienzo-core
+
+  - project: kiegroup/droolsjbpm-build-bootstrap
+
+  - project: kiegroup/drools
+
+default:
+  build-command:
+    current: |
+      cmd 1
+      cmd 2
+    upstream: cmd 3
+    after:
+      upstream: cmd 4
+    before:
+      downstream: cmd 5
+      current: cmd 12
+
+build:
+  - project: kiegroup/lienzo-core
+    build-command:
+      upstream: cmd 6
+      before: 
+        downstream: cmd 9
+
+  - project: kiegroup/droolsjbpm-build-bootstrap
+    build-command:
+      current: cmd 7
+      upstream: cmd 8
+      after: 
+        upstream: cmd 10
+        current: cmd 11

--- a/test/resources/construct-tree/build-without-default.yml
+++ b/test/resources/construct-tree/build-without-default.yml
@@ -1,0 +1,18 @@
+version: "2.1"
+
+dependencies:
+  - project: kiegroup/lienzo-core
+
+  - project: kiegroup/droolsjbpm-build-bootstrap
+
+  - project: kiegroup/drools
+
+
+build:
+  - project: kiegroup/droolsjbpm-build-bootstrap
+    build-command:
+      current: cmd 7
+      upstream: cmd 8
+      after: 
+        upstream: cmd 10
+        current: cmd 11

--- a/test/resources/construct-tree/missing-project.yml
+++ b/test/resources/construct-tree/missing-project.yml
@@ -1,0 +1,27 @@
+version: "2.1"
+
+dependencies:
+  - project: kiegroup/lienzo-core
+
+  - project: kiegroup/droolsjbpm-build-bootstrap
+    dependencies:
+      - project: kiegroup/lienzo
+
+default:
+  build-command:
+    current: |
+      mvn clean
+      mvn install
+    upstream: mvn -e --builder smart -T1C clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
+    after:
+      upstream: rm -rf ./*
+
+build:
+  - project: kiegroup/lienzo-core
+    build-command:
+      upstream: mvn -e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
+
+  - project: kiegroup/droolsjbpm-build-bootstrap
+    build-command:
+      current: mvn -e clean install -nsu -Prun-code-coverage,wildfly -Dfull  -Dintegration-tests=true -Dmaven.test.failure.ignore=true
+      upstream: mvn -e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true

--- a/test/resources/construct-tree/tree.yml
+++ b/test/resources/construct-tree/tree.yml
@@ -1,0 +1,81 @@
+version: "2.1"
+
+dependencies:
+  - project: kiegroup/lienzo-core
+
+  - project: kiegroup/kie-docs
+
+  - project: kiegroup/lienzo-tests
+    dependencies:
+      - project: kiegroup/lienzo-core
+
+  - project: kiegroup/droolsjbpm-build-bootstrap
+    dependencies:
+      - project: kiegroup/lienzo-core
+
+  - project: kiegroup/kie-soup
+    dependencies:
+      - project: kiegroup/droolsjbpm-build-bootstrap
+
+  - project: kiegroup/appformer
+    dependencies:
+      - project: kiegroup/droolsjbpm-build-bootstrap
+      - project: kiegroup/lienzo-tests
+      - project: kiegroup/kie-soup
+
+  - project: kiegroup/drools
+    dependencies:
+      - project: kiegroup/appformer
+      - project: kiegroup/kie-soup
+
+  - project: kiegroup/jbpm
+    dependencies:
+      - project: kiegroup/drools
+      - project: kiegroup/kie-soup
+
+  - project: kiegroup/optaplanner
+    dependencies:
+      - project: kiegroup/drools
+      - project: kiegroup/jbpm
+    mapping:
+      dependencies:
+        default:
+          - source: 7.x
+            target: main
+      dependant:
+        default:
+          - source: main
+            target: 7.x
+      exclude:
+        - kiegroup/optaweb-employee-rostering
+        - kiegroup/optaweb-vehicle-routing
+
+default:
+  build-command:
+    current: |
+      mvn clean
+      mvn install
+    upstream: mvn -e --builder smart -T1C clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
+    after:
+      upstream: rm -rf ./*
+
+build:
+  - project: kiegroup/appformer
+    build-command:
+      upstream: mvn -e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
+    archive-artifacts:
+      path: |
+        **/dashbuilder-runtime.war
+
+  - project: kiegroup/drools
+    build-command:
+      upstream: mvn -e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
+
+  - project: kiegroup/optaplanner
+    build-command:
+      current: mvn -e clean install -nsu -Prun-code-coverage,wildfly -Dfull  -Dintegration-tests=true -Dmaven.test.failure.ignore=true
+      upstream: mvn -e clean install -DskipTests -Dgwt.compiler.skip=true -Dgwt.skipCompilation=true -Denforcer.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Drevapi.skip=true
+
+  - project: kiegroup/kie-docs
+    build-command:
+      current: mvn clean install

--- a/test/tree.test.ts
+++ b/test/tree.test.ts
@@ -1,0 +1,118 @@
+import { Node } from "@bc-cr/domain/node";
+import * as reader from "@bc-cr/reader";
+import { getTree, getTreeForProject, parentChainFromNode } from "@bc-cr/tree";
+import * as constructTree from "@bc-cr/util/construct-tree";
+
+test("get tree", async () => {
+  const readDefinitionFileSpy = jest
+    .spyOn(reader, "readDefinitionFile")
+    .mockImplementation(async () => ({ dependencies: [], version: "2.1" }));
+  const constructTreeSpy = jest
+    .spyOn(constructTree, "constructTree")
+    .mockImplementation(() => []);
+  await expect(getTree("definitionFile")).resolves.toStrictEqual([]);
+  expect(readDefinitionFileSpy).toHaveBeenCalledTimes(1);
+  expect(constructTreeSpy).toHaveBeenCalledTimes(1);
+});
+
+const nodeChain: Node[] = [
+  {
+    project: "project1",
+    children: [
+      {
+        project: "project4",
+        children: [
+          {
+            project: "project6",
+            children: [],
+            parents: [
+              {
+                project: "project4",
+                children: [],
+                parents: [{ project: "project1", children: [], parents: [] }],
+              },
+            ],
+          },
+        ],
+        parents: [{ project: "project1", children: [], parents: [] }],
+      },
+      {
+        project: "project7",
+        children: [],
+        parents: [{ project: "project1", children: [], parents: [] }],
+      },
+    ],
+    parents: [],
+  },
+  { project: "project2", children: [], parents: [] },
+  {
+    project: "project3",
+    children: [
+      {
+        project: "project5",
+        children: [],
+        parents: [{ project: "project3", parents: [], children: [] }],
+      },
+    ],
+    parents: [],
+  },
+];
+
+test.each([
+  ["root", "project2", nodeChain[1]],
+  ["non-root", "project6", nodeChain[0].children[0].children[0]],
+  ["not found", "project10", undefined],
+])(
+  "get tree for project - %p",
+  async (_title: string, project: string, expected: Node | undefined) => {
+    jest
+      .spyOn(reader, "readDefinitionFile")
+      .mockImplementation(async () => ({ dependencies: [], version: "2.1" }));
+    jest
+      .spyOn(constructTree, "constructTree")
+      .mockImplementation(() => nodeChain);
+
+    await expect(
+      getTreeForProject("definitionFile", project)
+    ).resolves.toStrictEqual(expected);
+  }
+);
+
+test.each([
+  ["no parents", nodeChain[1], [nodeChain[1]]],
+  [
+    "parents",
+    nodeChain[0].children[0].children[0],
+    [
+      { project: "project1", children: [], parents: [] },
+      {
+        project: "project4",
+        children: [],
+        parents: [{ project: "project1", children: [], parents: [] }],
+      },
+      {
+        project: "project6",
+        children: [],
+        parents: [
+          {
+            project: "project4",
+            children: [],
+            parents: [{ project: "project1", children: [], parents: [] }],
+          },
+        ],
+      },
+    ],
+  ],
+])(
+  "get parent chain for node - %p",
+  (_title: string, project: Node, expected: Node[] | undefined) => {
+    jest
+      .spyOn(reader, "readDefinitionFile")
+      .mockImplementation(async () => ({ dependencies: [], version: "2.1" }));
+    jest
+      .spyOn(constructTree, "constructTree")
+      .mockImplementation(() => nodeChain);
+
+    expect(parentChainFromNode(project)).toStrictEqual(expected);
+  }
+);

--- a/test/util/construct-tree.test.ts
+++ b/test/util/construct-tree.test.ts
@@ -1,0 +1,191 @@
+import { Dependency } from "@bc-cr/domain/dependencies";
+import { readDefinitionFile } from "@bc-cr/reader";
+import { constructTree } from "@bc-cr/util/construct-tree";
+import path from "path";
+
+const resource = path.resolve(__dirname, "..", "resources", "construct-tree");
+
+test("missing project", async () => {
+  const definitionFile = await readDefinitionFile(
+    path.join(resource, "missing-project.yml")
+  );
+
+  expect(() =>
+    constructTree(
+      definitionFile.dependencies as Dependency[],
+      definitionFile.default?.["build-command"],
+      definitionFile.build
+    )
+  ).toThrowError(
+    "The project kiegroup/lienzo does not exist on project list. Please review your project definition file"
+  );
+});
+
+test("get build command with default", async () => {
+  const definitionFile = await readDefinitionFile(
+    path.join(resource, "build-with-default.yml")
+  );
+
+  const tree = constructTree(
+    definitionFile.dependencies as Dependency[],
+    definitionFile.default?.["build-command"],
+    definitionFile.build
+  );
+
+  expect(tree).toMatchObject([
+    {
+      project: "kiegroup/lienzo-core",
+      after: {
+        upstream: ["cmd 4"],
+        current: [],
+        downstream: [],
+      },
+      commands: {
+        upstream: ["cmd 6"],
+        current: ["cmd 1", "cmd 2"],
+        downstream: [],
+      },
+      before: {
+        downstream: ["cmd 9"],
+        current: ["cmd 12"],
+        upstream: [],
+      },
+    },
+    {
+      project: "kiegroup/droolsjbpm-build-bootstrap",
+      after: {
+        upstream: ["cmd 10"],
+        current: ["cmd 11"],
+        downstream: [],
+      },
+      commands: {
+        upstream: ["cmd 8"],
+        current: ["cmd 7"],
+        downstream: [],
+      },
+      before: {
+        downstream: ["cmd 5"],
+        current: ["cmd 12"],
+        upstream: [],
+      },
+    },
+    {
+      project: "kiegroup/drools",
+      after: {
+        upstream: ["cmd 4"],
+        current: [],
+        downstream: [],
+      },
+      commands: {
+        upstream: ["cmd 3"],
+        current: ["cmd 1", "cmd 2"],
+        downstream: [],
+      },
+      before: {
+        downstream: ["cmd 5"],
+        current: ["cmd 12"],
+        upstream: [],
+      },
+    },
+  ]);
+});
+
+test("get build command without default", async () => {
+  const definitionFile = await readDefinitionFile(
+    path.join(resource, "build-without-default.yml")
+  );
+
+  const tree = constructTree(
+    definitionFile.dependencies as Dependency[],
+    definitionFile.default?.["build-command"],
+    definitionFile.build
+  );
+
+  expect(tree).toMatchObject([
+    { project: "kiegroup/lienzo-core" },
+    {
+      project: "kiegroup/droolsjbpm-build-bootstrap",
+      after: {
+        upstream: ["cmd 10"],
+        current: ["cmd 11"],
+        downstream: [],
+      },
+      commands: {
+        upstream: ["cmd 8"],
+        current: ["cmd 7"],
+        downstream: [],
+      },
+    },
+    { project: "kiegroup/drools" },
+  ]);
+});
+
+test("tree structure", async () => {
+  const definitionFile = await readDefinitionFile(
+    path.join(resource, "tree.yml")
+  );
+
+  const tree = constructTree(
+    definitionFile.dependencies as Dependency[],
+    definitionFile.default?.["build-command"],
+    definitionFile.build
+  );
+
+  const optaplanner = {
+    project: "kiegroup/optaplanner",
+    parents: [{ project: "kiegroup/drools" }, { project: "kiegroup/jbpm" }],
+    children: [],
+  };
+
+  const jbpm = {
+    project: "kiegroup/jbpm",
+    parents: [{ project: "kiegroup/drools" }, { project: "kiegroup/kie-soup" }],
+    children: [optaplanner],
+  };
+
+  const drools = {
+    project: "kiegroup/drools",
+    parents: [
+      { project: "kiegroup/appformer" },
+      { project: "kiegroup/kie-soup" },
+    ],
+    children: [jbpm, optaplanner],
+  };
+
+  const appformer = {
+    project: "kiegroup/appformer",
+    parents: [
+      { project: "kiegroup/droolsjbpm-build-bootstrap" },
+      { project: "kiegroup/lienzo-tests" },
+      { project: "kiegroup/kie-soup" },
+    ],
+    children: [drools],
+  };
+
+  expect(tree).toMatchObject([
+    {
+      project: "kiegroup/lienzo-core",
+      parents: [],
+      children: [
+        {
+          project: "kiegroup/lienzo-tests",
+          parents: [{ project: "kiegroup/lienzo-core" }],
+          children: [appformer],
+        },
+        {
+          project: "kiegroup/droolsjbpm-build-bootstrap",
+          parents: [{ project: "kiegroup/lienzo-core" }],
+          children: [
+            {
+              project: "kiegroup/kie-soup",
+              parents: [{ project: "kiegroup/droolsjbpm-build-bootstrap" }],
+              children: [appformer, drools, jbpm],
+            },
+            appformer,
+          ],
+        },
+      ],
+    },
+    { project: "kiegroup/kie-docs", parents: [], children: [] },
+  ]);
+});


### PR DESCRIPTION
Resolves #40 
Implemented: 
- Constructing a tree from the given dependencies and build commands
- `getTree`, `getTreeForProject` and `parentChainFromNode`

I haven't removed the circular dependency issue since @Ginxo recommended that we implement the typescript version as is and then later on do these improvements. For the future, I would suggest having a proper Tree constructor and related methods as well as removing circular dependencies
