### PR TITLE
Extend definition file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -256,3 +256,4 @@ fabric.properties
 
 # End of https://www.toptal.com/developers/gitignore/api/node,webstorm
 
+.vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# V2.3.0
+
+- extension mechanism for definition file
+
 # V2.2.0
 
 - mapping changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kie/build-chain-configuration-reader",
-  "version": "2.2.6",
+  "version": "2.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kie/build-chain-configuration-reader",
-      "version": "2.2.6",
+      "version": "2.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "js-yaml": "^3.14.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kie/build-chain-configuration-reader",
-  "version": "2.2.6",
+  "version": "2.3.0",
   "description": "A library to read build-chain tool configuration files",
   "main": "index.js",
   "repository": {

--- a/src/lib/reader.js
+++ b/src/lib/reader.js
@@ -91,23 +91,23 @@ async function loadYaml(
   }
   definitionYaml.pre = extendPrePost(
     definitionYaml.pre,
-    extendedDefinitionFile?.pre
+    extendedDefinitionFile ? extendedDefinitionFile.pre : undefined
   );
   definitionYaml.post = extendPrePost(
     definitionYaml.post,
-    extendedDefinitionFile?.post
+    extendedDefinitionFile ? extendedDefinitionFile.post : undefined
   );
   definitionYaml.default = extendDefault(
     definitionYaml.default,
-    extendedDefinitionFile?.default
+    extendedDefinitionFile ? extendedDefinitionFile.default : undefined
   );
   definitionYaml.build = extendBuild(
     definitionYaml.build,
-    extendedDefinitionFile?.build
+    extendedDefinitionFile ? extendedDefinitionFile.build : undefined
   );
   definitionYaml.dependencies = await loadDependencies(
     definitionYaml.dependencies,
-    extendedDefinitionFile?.dependencies,
+    extendedDefinitionFile ? extendedDefinitionFile.dependencies : undefined,
     definitionFileFolder,
     containerPath,
     options
@@ -204,7 +204,7 @@ function extendDefault(current, extendWith) {
         : value;
     } else {
       // override extended definition file's value with the current one
-      copyCurrent[key] = current[key] ?? value;
+      copyCurrent[key] = current[key] ? current[key] : value;
     }
   });
   return copyCurrent;

--- a/src/lib/reader.js
+++ b/src/lib/reader.js
@@ -112,12 +112,12 @@ async function loadYaml(
     containerPath,
     options
   );
-  if (definitionYaml.dependencies) {
-    definitionYaml.dependencies
-      .filter(dependency => dependency.mapping)
-      .map(dependency => dependency.mapping)
-      .forEach(mapping => treatMapping(mapping));
-  }
+
+  definitionYaml.dependencies
+    .filter(dependency => dependency.mapping)
+    .map(dependency => dependency.mapping)
+    .forEach(mapping => treatMapping(mapping));
+
   return definitionYaml;
 }
 
@@ -135,14 +135,10 @@ async function loadDependencies(
   containerPath,
   options = { urlPlaceHolders: {}, token: undefined }
 ) {
-  if (!dependencies) {
-    return [];
-  }
-
-  let loadedDependencies = dependencies;
+  let loadedDependencies = dependencies ? dependencies : [];
 
   // if dependencies weren't embedded then load it from file or url
-  if (!Array.isArray(dependencies)) {
+  if (!Array.isArray(loadedDependencies)) {
     let dependenciesLocation = constructLocation(
       dependencies,
       containerPath,

--- a/src/lib/reader.js
+++ b/src/lib/reader.js
@@ -1,4 +1,5 @@
 const fs = require("fs");
+const path = require("path");
 
 const { getUrlContent } = require("./util/http");
 const { treatUrl, treatMapping } = require("./util/reader-util");
@@ -74,8 +75,39 @@ async function loadYaml(
   options = { urlPlaceHolders: {}, token: undefined }
 ) {
   validateDefinition(definitionYaml);
+  let extendedDefinitionFile;
+  if (definitionYaml.extends) {
+    const extendedDefinitionFileLocation = constructLocation(
+      definitionYaml.extends,
+      containerPath,
+      definitionFileFolder,
+      options
+    );
+    extendedDefinitionFile = await readDefinitionFile(
+      extendedDefinitionFileLocation,
+      options
+    );
+    delete definitionYaml["extends"];
+  }
+  definitionYaml.pre = extendPrePost(
+    definitionYaml.pre,
+    extendedDefinitionFile?.pre
+  );
+  definitionYaml.post = extendPrePost(
+    definitionYaml.post,
+    extendedDefinitionFile?.post
+  );
+  definitionYaml.default = extendDefault(
+    definitionYaml.default,
+    extendedDefinitionFile?.default
+  );
+  definitionYaml.build = extendBuild(
+    definitionYaml.build,
+    extendedDefinitionFile?.build
+  );
   definitionYaml.dependencies = await loadDependencies(
     definitionYaml.dependencies,
+    extendedDefinitionFile?.dependencies,
     definitionFileFolder,
     containerPath,
     options
@@ -98,59 +130,114 @@ async function loadYaml(
  */
 async function loadDependencies(
   dependencies,
+  extendedDependencies,
   definitionFileFolder,
   containerPath,
   options = { urlPlaceHolders: {}, token: undefined }
 ) {
-  if (dependencies) {
-    let dependenciesFinalPath =
-      !Array.isArray(dependencies) && dependencies.startsWith("http")
-        ? treatUrl(dependencies, options.urlPlaceHolders)
-        : dependencies;
-    if (
-      containerPath.startsWith("http") &&
-      !Array.isArray(dependencies) &&
-      !dependencies.startsWith("http")
-    ) {
-      const treatedUrl = treatUrl(containerPath, options.urlPlaceHolders);
-      dependenciesFinalPath = `${treatedUrl.substring(
-        0,
-        treatedUrl.lastIndexOf("/")
-      )}/${dependencies}`;
-      const dependenciesContent = await getUrlContent(
-        dependenciesFinalPath,
-        options.token
-      );
-      fs.writeFileSync(dependencies, dependenciesContent);
-    }
-
-    if (!Array.isArray(dependencies)) {
-      const dependenciesFilePath = dependencies.startsWith("http")
-        ? treatUrl(dependencies, options.urlPlaceHolders)
-        : `${definitionFileFolder}/${dependencies}`;
-      const dependenciesFileContent = dependencies.startsWith("http")
-        ? await getUrlContent(dependenciesFilePath, options.token)
-        : fs.readFileSync(dependenciesFilePath, "utf8");
-      const dependenciesYaml = readYaml(dependenciesFileContent);
-      validateDependencies(dependenciesYaml);
-      // Once the dependencies are loaded, the `extends` proporty is concatenated to the current dependencies
-      return (
-        await loadDependencies(
-          dependenciesYaml.extends,
-          dependenciesFilePath.substring(
-            0,
-            dependenciesFilePath.lastIndexOf("/")
-          ),
-          dependenciesFinalPath,
-          options
-        )
-      ).concat(dependenciesYaml.dependencies);
-    } else {
-      // There's no extension for embedded dependencies
-      return dependencies;
-    }
-  } else {
+  if (!dependencies) {
     return [];
+  }
+
+  let loadedDependencies = dependencies;
+
+  // if dependencies weren't embedded then load it from file or url
+  if (!Array.isArray(dependencies)) {
+    let dependenciesLocation = constructLocation(
+      dependencies,
+      containerPath,
+      definitionFileFolder,
+      options
+    );
+    const dependenciesYaml = await readDefinitionFile(
+      dependenciesLocation,
+      options
+    );
+    validateDependencies(dependenciesYaml);
+    loadedDependencies = dependenciesYaml.dependencies;
+  }
+
+  // extend loaded dependencies if needed
+  return extendedDependencies
+    ? extendedDependencies.concat(loadedDependencies)
+    : loadedDependencies;
+}
+
+function extendBuild(current, extendWith) {
+  if (!extendWith) {
+    return current;
+  }
+
+  if (!current) {
+    return extendWith;
+  }
+
+  const copyCurrent = [...current];
+
+  extendWith.map(parent => {
+    // only add if it doesn't exist in the current build. current build overrides parent
+    if (!current.find(current => current.project === parent.project)) {
+      copyCurrent.push(parent);
+    }
+  });
+
+  return copyCurrent;
+}
+
+function extendDefault(current, extendWith) {
+  if (!extendWith) {
+    return current;
+  }
+
+  if (!current) {
+    return extendWith;
+  }
+
+  const copyCurrent = { ...current };
+  const currentKeys = Object.keys(current);
+
+  Object.entries(extendWith).forEach(([key, value]) => {
+    if (typeof value === "object") {
+      // if current as the key then merge the 2 objects otherwise use the object from extended
+      copyCurrent[key] = currentKeys.includes(key)
+        ? extendDefault(current[key], value)
+        : value;
+    } else {
+      // override extended definition file's value with the current one
+      copyCurrent[key] = current[key] ?? value;
+    }
+  });
+  return copyCurrent;
+}
+
+function extendPrePost(current, extendWith) {
+  if (!extendWith) {
+    return current;
+  }
+
+  if (!current) {
+    return extendWith;
+  }
+
+  return `${current}\n${extendWith}`;
+}
+
+function constructLocation(location, containerPath, parentDir, options) {
+  if (location.startsWith("http")) {
+    return treatUrl(location, options.urlPlaceHolders);
+  }
+  // if location is a file path and container path was a url
+  else if (containerPath.startsWith("http")) {
+    const treatedContainerUrl = treatUrl(
+      containerPath,
+      options.urlPlaceHolders
+    );
+    return `${treatedContainerUrl.substring(
+      0,
+      treatedContainerUrl.lastIndexOf("/")
+    )}/${location}`;
+  } else {
+    return path.join(parentDir, location);
   }
 }
 

--- a/src/lib/util/validations.js
+++ b/src/lib/util/validations.js
@@ -1,6 +1,6 @@
 const assert = require("assert");
 
-const allowedVersions = ["2.1"];
+const allowedVersions = ["2.1", "2.2"];
 
 function validateDefinition(definition) {
   assert(

--- a/test/resources/build-config.yaml
+++ b/test/resources/build-config.yaml
@@ -2,6 +2,9 @@ version: "2.1"
 
 dependencies: ./project-dependencies.yaml
 
+pre: |
+  world
+
 default:
   build-command:
     current: mvn -e -nsu -Dfull -Pwildfly clean install -Prun-code-coverage  -Dcontainer.profile=wildfly -Dcontainer=wildfly -Dintegration-tests=true -Dmaven.test.failure.ignore=true

--- a/test/resources/extend-dependency.yaml
+++ b/test/resources/extend-dependency.yaml
@@ -1,0 +1,6 @@
+version: "2.2"
+
+dependencies:
+  - project: kiegroup/new-project
+    dependencies:
+      - project: kiegroup/appformer

--- a/test/resources/extend-from-file.yaml
+++ b/test/resources/extend-from-file.yaml
@@ -1,0 +1,30 @@
+version: "2.2"
+
+extends: ./build-config.yaml
+
+pre: hello
+
+dependencies:
+  - project: kiegroup/new-project
+    dependencies:
+      - project: kiegroup/appformer
+
+default:
+  build-command:
+    current: echo overriden
+    after:
+      downstream: rm -rf ./*
+
+build:
+  - project: kiegroup/appformer
+    build-command:
+      upstream: echo changed
+    archive-artifacts:
+      path: |
+        **/dashbuilder-runtime.war
+        **/something
+
+  - project: kiegroup/new-project
+    build-command:
+      current: echo new-project
+

--- a/test/resources/extend-from-url.yaml
+++ b/test/resources/extend-from-url.yaml
@@ -1,0 +1,30 @@
+version: "2.2"
+
+extends: https://whatever-url.com/definition-file.yaml
+
+post: hello
+
+dependencies:
+  - project: kiegroup/new-project
+    dependencies:
+      - project: kiegroup/appformer
+
+default:
+  build-command:
+    current: echo overriden
+    after:
+      downstream: rm -rf ./*
+
+build:
+  - project: kiegroup/appformer
+    build-command:
+      upstream: echo changed
+    archive-artifacts:
+      path: |
+        **/dashbuilder-runtime.war
+        **/something
+
+  - project: kiegroup/new-project
+    build-command:
+      current: echo new-project
+

--- a/test/resources/extend-multilevel.yaml
+++ b/test/resources/extend-multilevel.yaml
@@ -1,0 +1,22 @@
+version: "2.2"
+
+extends: ./extend-from-file.yaml
+
+default:
+  build-command:
+    current: echo overriden again
+    after:
+      downstream: echo overriden
+
+build:
+  - project: kiegroup/appformer
+    build-command:
+      upstream: echo changed again
+    archive-artifacts:
+      path: |
+        **/dashbuilder-runtime.war
+        **/something
+
+  - project: kiegroup/new-project
+    build-command:
+      current: echo updated

--- a/test/resources/extend-with-dependency-from-file.yaml
+++ b/test/resources/extend-with-dependency-from-file.yaml
@@ -1,0 +1,25 @@
+version: "2.2"
+
+extends: ./build-config.yaml
+
+dependencies: ./extend-dependency.yaml
+
+default:
+  build-command:
+    current: echo overriden
+    after:
+      downstream: rm -rf ./*
+
+build:
+  - project: kiegroup/appformer
+    build-command:
+      upstream: echo changed
+    archive-artifacts:
+      path: |
+        **/dashbuilder-runtime.war
+        **/something
+
+  - project: kiegroup/new-project
+    build-command:
+      current: echo new-project
+


### PR DESCRIPTION
Resolves #57 

Added extension for definition file. In the process refactored and removed some unnecessary code in `loadDependencies` such as:
- Unnecessary write to file when we are going to read it again at https://github.com/kiegroup/build-chain-configuration-reader/blob/main/src/lib/reader.js#L124
- 2 variables to store location of definition file [`dependenciesFinalPath`](https://github.com/kiegroup/build-chain-configuration-reader/blob/main/src/lib/reader.js#L116) and [`dependenciesFilePath`](https://github.com/kiegroup/build-chain-configuration-reader/blob/main/src/lib/reader.js#L116)
- and more

The refactor should make it more readable and modular. No test cases were changed. Only new ones to test extension were added. Hence, the refactor shouldn't break any of the previous functionality.



