### PR TITLE
fixed bug which added undefined node objects to parent/children field…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ coverage/
 test-report.xml
 .idea/
 .vscode/
-./build/
+build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# V3.0.7
+
+- Fixed bug where children/parent fields of a node stored undefined node objects
+
 # V3.0.6
 
 - Added skip field

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kie/build-chain-configuration-reader",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kie/build-chain-configuration-reader",
-      "version": "3.0.6",
+      "version": "3.0.7",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kie/build-chain-configuration-reader",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "description": "A library to read build-chain tool configuration files",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",

--- a/src/util/construct-tree.ts
+++ b/src/util/construct-tree.ts
@@ -31,12 +31,15 @@ export function constructTree(
           );
         }
 
-        // add current dependency as child of the parentDependency
-        map[parentDependency.project].children.push(map[dependency.project]);
+        // add only if it was not skipped
+        if (map[dependency.project]) {
+          // add current dependency as child of the parentDependency
+          map[parentDependency.project].children.push(map[dependency.project]);
 
-        // store a reference of the parent in the child as well
-        // using a string instead of Node to avoid circular dependency
-        map[dependency.project].parents.push(map[parentDependency.project]);
+          // store a reference of the parent in the child as well
+          // using a string instead of Node to avoid circular dependency
+          map[dependency.project].parents.push(map[parentDependency.project]);
+        }
       });
     }
     // roots array contains nodes which don't have any parents


### PR DESCRIPTION
The parent/children field of a node object sometimes contained undefined node object causing failures in various tree helper functions.

Refer https://github.com/kiegroup/github-action-build-chain/issues/331 to reproduce issue