### PR TITLE
Added `@always` as valid `on` for archive artifact paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# V3.0.8
+
+- Add `@always` as valid `on` for archive artifact paths
+
 # V3.0.7
 
 - Fixed bug where children/parent fields of a node stored undefined node objects

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kie/build-chain-configuration-reader",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kie/build-chain-configuration-reader",
-      "version": "3.0.7",
+      "version": "3.0.8",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kie/build-chain-configuration-reader",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "description": "A library to read build-chain tool configuration files",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",

--- a/src/domain/archive-artifacts.ts
+++ b/src/domain/archive-artifacts.ts
@@ -11,6 +11,7 @@ export interface ArchiveArtifacts {
 export enum ArchiveOn {
   SUCCESS = "success",
   FAILURE = "failure",
+  ALWAYS = "always"
 }
 
 export enum IfNoFile {

--- a/src/reader.ts
+++ b/src/reader.ts
@@ -60,7 +60,7 @@ export async function readDefinitionFile(location: string, opts?: ReaderOpts) {
     targetExpressionToTarget(definitionFile.dependencies);
     return definitionFile;
   } catch (err) {
-    throw new Error(`Error getting ${location}. Error: ${JSON.stringify(err)}`);
+    throw new Error(`Error getting ${location} - ${err}`);
   }
 }
 

--- a/src/schema/archive-artifacts.ts
+++ b/src/schema/archive-artifacts.ts
@@ -12,7 +12,7 @@ export const ArchiveArtifactSchema: JSONSchemaType<ArchiveArtifacts> = {
         type: "object",
         properties: {
           path: { type: "string" },
-          on: { type: "string", enum: ["success", "failure"] },
+          on: { type: "string", enum: ["success", "failure", "always"] },
         },
         required: ["on", "path"]
       },

--- a/src/util/yaml.ts
+++ b/src/util/yaml.ts
@@ -149,7 +149,7 @@ function transformPath(path: string[]) {
       const index = p.lastIndexOf("@");
       return {
         path: index === -1 ? p : p.slice(0, index),
-        on: index === -1 ? "success" : p.slice(index),
+        on: index === -1 ? "success" : p.slice(index + 1),
       };
     }
   });


### PR DESCRIPTION
Fixes #73 

- Added `@always` as valid `on` for archive artifact paths
- Improved error msg for validation failures