### PR TITLE
Override project when defined in dependency file and extends file 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kie/build-chain-configuration-reader",
-  "version": "3.0.13",
+  "version": "3.0.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kie/build-chain-configuration-reader",
-      "version": "3.0.13",
+      "version": "3.0.14",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kie/build-chain-configuration-reader",
-  "version": "3.0.13",
+  "version": "3.0.14",
   "description": "A library to read build-chain tool configuration files",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",

--- a/src/reader.ts
+++ b/src/reader.ts
@@ -94,7 +94,12 @@ async function loadDependencies(
 
   // extend loaded dependencies if needed
   return extendedDependencies
-    ? extendedDependencies.concat(loadedDependencies)
+    ? loadedDependencies.concat(
+      // pick current dependency over extended if project is defined in both
+      extendedDependencies.filter(ed => 
+        !loadedDependencies.find(ld => ed.project === ld.project)
+      )
+    )
     : loadedDependencies;
 }
 

--- a/test/reader.test.ts
+++ b/test/reader.test.ts
@@ -13,9 +13,14 @@ describe("get content", () => {
     );
     expect(definitionFile).toEqual({
       version: "2.1",
-      dependencies: Array(2).fill({
-        project: "owner1/project1",
-      }),
+      dependencies: [
+        {
+          project: "owner1/project1",
+        },
+        {
+          project: "owner1/project2",
+        }
+      ],
     });
   });
 
@@ -31,9 +36,14 @@ describe("get content", () => {
     );
     expect(definitionFile).toEqual({
       version: "2.1",
-      dependencies: Array(2).fill({
-        project: "owner1/project1",
-      }),
+      dependencies: [
+        {
+          project: "owner1/project1",
+        },
+        {
+          project: "owner1/project2",
+        }
+      ],
     });
   });
 
@@ -50,9 +60,14 @@ describe("get content", () => {
     );
     expect(definitionFile).toEqual({
       version: "2.1",
-      dependencies: Array(2).fill({
-        project: "owner1/project1",
-      }),
+      dependencies: [
+        {
+          project: "owner1/project1",
+        },
+        {
+          project: "owner1/project2",
+        }
+      ],
     });
   });
 
@@ -157,11 +172,11 @@ describe("definition file with extends", () => {
     expect(result.post).toBe(undefined);
     expect(result.pre).toStrictEqual(["hello", "world"]);
     expect(result.dependencies).toEqual([
-      ...expected.dependencies!,
       {
         project: "kiegroup/new-project",
         dependencies: [{ project: "kiegroup/appformer" }],
       },
+      ...expected.dependencies!,
     ]);
     expect(result.default).toEqual({
       "build-command": {
@@ -234,11 +249,11 @@ describe("definition file with extends", () => {
     expect(result.post).toBe(undefined);
     expect(result.pre).toStrictEqual(["hello", "world"]);
     expect(result.dependencies).toEqual([
-      ...expected.dependencies!,
       {
         project: "kiegroup/new-project",
         dependencies: [{ project: "kiegroup/appformer" }],
       },
+      ...expected.dependencies!,
     ]);
     expect(result.default).toEqual({
       "build-command": {
@@ -309,11 +324,11 @@ describe("definition file with extends", () => {
     expect(result.pre).toStrictEqual(["world"]);
     expect(result.post).toStrictEqual({success: ["hello"]});
     expect(result.dependencies).toEqual([
-      ...expected.dependencies!,
       {
         project: "kiegroup/new-project",
         dependencies: [{ project: "kiegroup/appformer" }],
       },
+      ...expected.dependencies!,
     ]);
     expect(result.default).toEqual({
       "build-command": {
@@ -375,11 +390,11 @@ describe("definition file with extends", () => {
     expect(result.version).toBe("2.2");
     expect(result.extends).toBe(undefined);
     expect(result.dependencies).toEqual([
-      ...expected.dependencies!,
       {
         project: "kiegroup/new-project",
         dependencies: [{ project: "kiegroup/appformer" }],
       },
+      ...expected.dependencies!,
     ]);
     expect(result.default).toEqual({
       "build-command": {
@@ -443,11 +458,11 @@ describe("definition file with extends", () => {
     expect(result.post).toBe(undefined);
     expect(result.pre).toStrictEqual(["hello", "world"]);
     expect(result.dependencies).toEqual([
-      ...expected.dependencies!,
       {
         project: "kiegroup/new-project",
         dependencies: [{ project: "kiegroup/appformer" }],
       },
+      ...expected.dependencies!,     
     ]);
     expect(result.default).toEqual({
       "build-command": {
@@ -498,6 +513,23 @@ describe("definition file with extends", () => {
       ...expected.build!.filter(
         build => build.project !== "kiegroup/appformer"
       ),
+    ]);
+  });
+});
+
+describe("dependencies with extends", () => {
+  test("override dependency with current value if defined in extends and current dependency file", async () => {
+    const result = await readDefinitionFile(
+      path.join(resourcePath, "extends-dependency-definition-file.yml")
+    );
+    expect(result.dependencies).toEqual([
+      {
+        project: "owner1/project1",
+        dependencies: [{ project: "owner1/project2" }],
+      },
+      {
+        project: "owner1/project2",
+      },
     ]);
   });
 });

--- a/test/resources/reader-tests/content.yml
+++ b/test/resources/reader-tests/content.yml
@@ -1,4 +1,4 @@
 version: "2.1"
 dependencies:
   - project: owner1/project1
-  - project: owner1/project1
+  - project: owner1/project2

--- a/test/resources/reader-tests/extends-dependency-definition-file.yml
+++ b/test/resources/reader-tests/extends-dependency-definition-file.yml
@@ -1,0 +1,12 @@
+version: "2.1"
+
+dependencies: ./extends-dependency.yml
+
+default:
+  build-command:
+    current: mvn clean install -Dproductized=true -DskipTests=true ${{ env.BUILD_MVN_OPTS }}
+    upstream: mvn clean install -Dquickly -Dproductized=true -DskipTests=true ${{ env.BUILD_MVN_OPTS }} 
+    downstream: mvn clean install -Dquickly -Dproductized=true -DskipTests=true ${{ env.BUILD_MVN_OPTS }} 
+    after:
+      current: |
+        docker system prune -f 

--- a/test/resources/reader-tests/extends-dependency.yml
+++ b/test/resources/reader-tests/extends-dependency.yml
@@ -1,0 +1,8 @@
+version: "2.1"
+
+extends: ./content.yml
+
+dependencies:
+  - project: owner1/project1
+    dependencies:
+      - project: owner1/project2


### PR DESCRIPTION
Fixes #91 

Override the project in dependencies if it is defined in the current definition file and extended definition file. We will use the value defined in the current definition file.