### PR TITLE
remove node 14

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 16
           registry-url: https://registry.npmjs.org/
       - run: npm install
       - run: npm run build

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [16.x]
         os: [ubuntu-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kie/build-chain-configuration-reader",
-  "version": "3.0.14",
+  "version": "4.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kie/build-chain-configuration-reader",
-      "version": "3.0.14",
+      "version": "4.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.11.0",
@@ -27,6 +27,9 @@
         "ts-node": "^10.8.1",
         "tsc-alias": "^1.7.1",
         "typescript": "^4.7.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kie/build-chain-configuration-reader",
-  "version": "3.0.14",
+  "version": "4.0.0",
   "description": "A library to read build-chain tool configuration files",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -47,5 +47,8 @@
     "ajv": "^8.11.0",
     "axios": "^0.27.2",
     "yaml": "^2.1.1"
+  },
+  "engines": {
+    "node": ">=16.0.0"
   }
 }


### PR DESCRIPTION
Relates to:
* https://github.com/kiegroup/github-action-build-chain/issues/405

Making a new major release since all the previous version were built in node 14
