### PR TITLE
automate build-chain-configuration-reader updates

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,3 +21,15 @@ jobs:
       - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+      - name: get-package-version
+        id: package-version
+        run: |
+          PACKAGE_VERSION=$(npm version | grep @kie/build-chain-configuration-reader | sed -re "s/'.*': '(.*)',?/\1/g" | tr -d '[:space:]')
+          echo "current-version=${PACKAGE_VERSION}" >> $GITHUB_OUTPUT
+      - name: Update github-action-build-chain 
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.UPDATE_BUILD_CHAIN }}
+          repository: kiegroup/github-action-build-chain
+          event-type: update-build-chain-configuration-reader
+          client-payload: '{"version": "${{ steps.package-version.outputs.current-version }}"}'


### PR DESCRIPTION
Fixes https://github.com/kiegroup/github-action-build-chain/issues/424

This dispatches an event to github-action-build-chain after it publishes a new version of this package. The dispatched event contains the new package version
