### PR TITLE
track depth of each project in dependency graph

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kie/build-chain-configuration-reader",
-  "version": "3.0.15",
+  "version": "3.0.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kie/build-chain-configuration-reader",
-      "version": "3.0.15",
+      "version": "3.0.16",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.11.0",
@@ -5116,9 +5116,9 @@
       "dev": true
     },
     "node_modules/yaml": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.3.tgz",
-      "integrity": "sha512-AacA8nRULjKMX2DvWvOAdBZMOfQlypSFkjcOcu9FalllIDJ1kvlREzcdIZmidQUqqeMv7jorHjq2HlLv/+c2lg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
+      "integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==",
       "engines": {
         "node": ">= 14"
       }
@@ -8934,9 +8934,9 @@
       "dev": true
     },
     "yaml": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.3.tgz",
-      "integrity": "sha512-AacA8nRULjKMX2DvWvOAdBZMOfQlypSFkjcOcu9FalllIDJ1kvlREzcdIZmidQUqqeMv7jorHjq2HlLv/+c2lg=="
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
+      "integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA=="
     },
     "yargs": {
       "version": "17.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kie/build-chain-configuration-reader",
-  "version": "3.0.15",
+  "version": "3.0.16",
   "description": "A library to read build-chain tool configuration files",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",

--- a/src/domain/graph.ts
+++ b/src/domain/graph.ts
@@ -5,6 +5,7 @@ export type Graph = {
     incoming: Set<string>
     outgoing: Set<string>
     dependency: Dependency
+    depth: number
   }
 }
 

--- a/src/domain/node.ts
+++ b/src/domain/node.ts
@@ -6,6 +6,7 @@ export interface Node {
   project: string;
   parents: Node[];
   children: Node[];
+  depth: number;
   before?: CommandLevel;
   commands?: CommandLevel;
   after?: CommandLevel;

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -1,7 +1,8 @@
 import { Dependency } from "@bc-cr/domain/dependencies";
+import { Graph, Visited } from "@bc-cr/domain/graph";
 import { ReaderOpts } from "@bc-cr/domain/readerOptions";
 import { readDefinitionFile } from "@bc-cr/reader";
-import { constructGraph, DFS } from "@bc-cr/util/construct-graph";
+import { constructGraph } from "@bc-cr/util/construct-graph";
 import { constructNode } from "@bc-cr/util/construct-node";
 
 export async function getUpstreamProjects(
@@ -10,9 +11,14 @@ export async function getUpstreamProjects(
   opts?: ReaderOpts) {
     const definitionFile = await readDefinitionFile(definitionFileLocation, opts);
     const graph = constructGraph(definitionFile.dependencies as Dependency[]);
-    return DFS(project, graph, true)
+    return dfs(project, graph, true)
     .map(
-      p => constructNode(p, definitionFile.default?.["build-command"], definitionFile.build)
+      p => constructNode(
+        p, 
+        definitionFile.default?.["build-command"], 
+        definitionFile.build,
+        graph[p.project].depth
+      )
     );
 }
 
@@ -21,7 +27,90 @@ export async function getFullDownstreamProjects(definitionFileLocation: string,
   opts?: ReaderOpts) {
     const definitionFile = await readDefinitionFile(definitionFileLocation, opts);
     const graph = constructGraph(definitionFile.dependencies as Dependency[]);
-    return DFS(project, graph).map(
-      p => constructNode(p, definitionFile.default?.["build-command"], definitionFile.build)
+    return dfs(project, graph).map(
+      p => constructNode(
+        p, 
+        definitionFile.default?.["build-command"], 
+        definitionFile.build,
+        graph[p.project].depth
+      )
     );
+}
+
+/**
+ * Depth First Search on a graph starting at a given project.
+ * Additional Constraints: 
+ *     For any node, visit all its outgoing edges before visiting incoming edges
+ */
+function dfs(project: string, graph: Graph, outgoingOnly = false) {
+  const result: Dependency[] = [];
+  const visited = Object.keys(graph).reduce((visited: Record<string, Visited>, curr: string) => {
+    visited[curr] = Visited.VISITED_NONE;
+    return visited;
+  }, {});
+  if (outgoingOnly) {
+    visitOutgoingEdges(project, graph, visited, result);
+  } else {
+    visit(project, graph, visited, result);
+  }
+  return result;
+}
+
+/**
+ * DFS on only outgoing edges. We essentially want a topological sort
+ * src: https://en.wikipedia.org/wiki/Topological_sorting#Depth-first_search
+ * 
+ * We will also store depth of each vertex. 
+ * Depth of a vertex is defined as the longest distance between the vertex and a root node (i.e. vertex with no outgoing edges or a source)
+ */
+function visitOutgoingEdges(project: string, graph: Graph, visited: Record<string, Visited>, result: Dependency[]) {
+  // check whether node already has a temporary mark in which case we have a cycle that cant be resolved
+  if (visited[project] === Visited.VISITING_OUTGOING) {
+    throw new Error("Cycle detected");
+  }
+
+  // if the node has not already been visited
+  if (visited[project] === Visited.VISITED_NONE) {
+    // mark the node with a temporary mark
+    visited[project] = Visited.VISITING_OUTGOING;
+
+    let maxDepth = graph[project].depth;
+    for (const dependency of graph[project].outgoing) {
+      const currDepth = visitOutgoingEdges(dependency, graph, visited, result);
+      if (currDepth > maxDepth) {
+        maxDepth = currDepth;
+      }
+    }
+
+    // update the depth of the current project
+    graph[project].depth = maxDepth + 1;
+
+    // mark the node with a permanent mark
+    visited[project] = Visited.VISITED_OUTGOING;
+    result.push(graph[project].dependency);
+  }
+  return graph[project].depth;
+}
+
+function visit(project: string, graph: Graph, visited: Record<string, Visited>, result: Dependency[]) {
+  // before visiting the incoming edge of the current project, visit all its outgoing edges (i.e dependencies)
+  visitOutgoingEdges(project, graph, visited, result);
+
+  // if the node has not already been visited
+  if (visited[project] !== Visited.VISITED_ALL) {
+    // check whether node already has a temporary mark in which case we have a cycle that cant be resolved
+    if (visited[project] === Visited.VISITING_INCOMING) {
+      throw new Error("Cycle detected");
+    }
+
+    // mark the node with a temporary mark
+    visited[project] = Visited.VISITING_INCOMING;
+
+    for (const dependant of graph[project].incoming) {
+      visit(dependant, graph, visited, result);
+    }
+
+    // mark the node with a permanent mark. no need to add it to result since visitOutgoingEdges already does that
+    visited[project] = Visited.VISITED_ALL;
+  }  
 }

--- a/src/util/construct-graph.ts
+++ b/src/util/construct-graph.ts
@@ -1,5 +1,5 @@
 import { Dependency } from "@bc-cr/domain/dependencies";
-import { Graph, Visited } from "@bc-cr/domain/graph";
+import { Graph } from "@bc-cr/domain/graph";
 
 export function constructGraph(
   dependencies: Dependency[],
@@ -33,81 +33,13 @@ export function constructGraph(
   return graph;
 }
 
-/**
- * Depth First Search on a graph starting at a given project.
- * Additional Constraints: 
- *     For any node, visit all its outgoing edges before visiting incoming edges
- */
-export function DFS(project: string, graph: Graph, outgoingOnly = false) {
-  const result: Dependency[] = [];
-  const visited = Object.keys(graph).reduce((visited: Record<string, Visited>, curr: string) => {
-    visited[curr] = Visited.VISITED_NONE;
-    return visited;
-  }, {});
-  if (outgoingOnly) {
-    visitOutgoingEdges(project, graph, visited, result);
-  } else {
-    visit(project, graph, visited, result);
-  }
-  return result;
-}
-
-/**
- * DFS on only outgoing edges. We essentially want a topological sort
- * src: https://en.wikipedia.org/wiki/Topological_sorting#Depth-first_search
- */
-function visitOutgoingEdges(project: string, graph: Graph, visited: Record<string, Visited>, result: Dependency[]) {
-  // check whether node already has a temporary mark in which case we have a cycle that cant be resolved
-  if (visited[project] === Visited.VISITING_OUTGOING) {
-    throw new Error("Cycle detected");
-  }
-
-  // if the node has not already been visited
-  if (visited[project] === Visited.VISITED_NONE) {
-    // mark the node with a temporary mark
-    visited[project] = Visited.VISITING_OUTGOING;
-
-    for (const dependency of graph[project].outgoing) {
-      visitOutgoingEdges(dependency, graph, visited, result);
-    }
-
-    // mark the node with a permanent mark
-    visited[project] = Visited.VISITED_OUTGOING;
-    result.push(graph[project].dependency);
-  }
-}
-
-function visit(project: string, graph: Graph, visited: Record<string, Visited>, result: Dependency[]) {
-  // DFS on outgoing edges first
-  visitOutgoingEdges(project, graph, visited, result);
-
-  // if the node has not already been visited
-  if (visited[project] !== Visited.VISITED_ALL) {
-    // check whether node already has a temporary mark in which case we have a cycle that cant be resolved
-    if (visited[project] === Visited.VISITING_INCOMING) {
-      throw new Error("Cycle detected");
-    }
-
-    // mark the node with a temporary mark
-    visited[project] = Visited.VISITING_INCOMING;
-
-    for (const dependant of graph[project].incoming) {
-      // before visiting the incoming edge of the current dependant, visit all its outgoing edges (i.e dependencies)
-      visitOutgoingEdges(dependant, graph, visited, result);
-      visit(dependant, graph, visited, result);
-    }
-
-    // mark the node with a permanent mark. no need to add it to result since visitOutgoingEdges already does that
-    visited[project] = Visited.VISITED_ALL;
-  }  
-}
-
 function initializeVertex(dependency: Dependency, graph: Graph) {
   if (!graph[dependency.project]) {
     graph[dependency.project] = {
       incoming: new Set(),
       outgoing: new Set(),
-      dependency
+      dependency,
+      depth: -1
     };
   }
 }

--- a/src/util/construct-node.ts
+++ b/src/util/construct-node.ts
@@ -5,7 +5,8 @@ import { Node } from "@bc-cr/domain/node";
 export function constructNode(
   dependency: Dependency,
   defaultBuild?: BuildCommand,
-  build?: Build[]
+  build?: Build[],
+  depth = 0
 ): Node {
   const buildConfig = findBuildConfigForProject(dependency.project, build);
   const clone = buildConfig?.clone;
@@ -18,6 +19,7 @@ export function constructNode(
     mapping: dependency.mapping,
     before: buildCommand?.before,
     after: buildCommand?.after,
+    depth,
     commands: {
       upstream: buildCommand?.upstream ?? [],
       downstream: buildCommand?.downstream ?? [],

--- a/test/graph.test.ts
+++ b/test/graph.test.ts
@@ -3,6 +3,29 @@ import { Node } from "@bc-cr/domain/node";
 import { getOrderedListForProject, getTreeForProject, parentChainFromNode } from "@bc-cr/tree";
 import path from "path";
 
+const expectedDepths: Record<string, number> = {
+  "kiegroup/lienzo-core": 0,
+  "kiegroup/droolsjbpm-build-bootstrap": 0,
+  "kiegroup/lienzo-tests": 1,
+  "kiegroup/kie-soup": 1,
+  "kiegroup/appformer": 2,
+  "kiegroup/kie-uberfire-extensions": 3,
+  "kiegroup/droolsjbpm-knowledge": 2,
+  "kiegroup/drools": 3,
+  "kiegroup/jbpm": 4,
+  "kiegroup/optaplanner": 4,
+  "kiegroup/droolsjbpm-integration": 5,
+  "kiegroup/kie-wb-playground": 6,
+  "kiegroup/kie-wb-common": 7,
+  "kiegroup/drools-wb": 8,
+  "kiegroup/jbpm-work-items": 6,
+  "kiegroup/jbpm-wb": 9,
+  "kiegroup/optaplanner-wb": 9,
+  "kiegroup/kie-wb-distributions": 10,
+  "kiegroup/process-migration-service": 6,
+  "kiegroup/kie-jpmml-integration": 5
+};
+
 test.each([
   [
     "kiegroup/lienzo-core",
@@ -253,6 +276,7 @@ test.each([
     project,
     result
   );
+  result.forEach(r => expect(r.depth).toBe(expectedDepths[r.project]));
 });
 
 test.each([
@@ -721,6 +745,7 @@ test.each([
     project,
     result
   );
+  result.forEach(r => expect(r.depth).toBe(expectedDepths[r.project]));
 });
 
 async function verifyFullDowstreamAgainstTreeImplementation(definitionFile: string, project: string, result: Node[]) {

--- a/test/util/construct-graph.test.ts
+++ b/test/util/construct-graph.test.ts
@@ -1,0 +1,48 @@
+import { Dependency } from "@bc-cr/domain/dependencies";
+import { readDefinitionFile } from "@bc-cr/reader";
+import { constructGraph } from "@bc-cr/util/construct-graph";
+import path from "path";
+
+const resource = path.resolve(__dirname, "..", "resources", "construct-tree");
+
+test("missing project", async () => {
+  const definitionFile = await readDefinitionFile(
+    path.join(resource, "missing-project.yml")
+  );
+
+  expect(() =>
+    constructGraph(
+      definitionFile.dependencies as Dependency[],
+    )
+  ).toThrowError(
+    "The project kiegroup/lienzo does not exist on project list. Please review your project definition file"
+  );
+});
+
+test("graph structure", async () => {
+  const definitionFile = await readDefinitionFile(
+    path.join(resource, "tree.yml")
+  );
+
+  const graph = constructGraph(
+    definitionFile.dependencies as Dependency[],
+  );
+
+  expect(graph).toMatchObject({
+    "kiegroup/lienzo-core": {
+      incoming: new Set(["kiegroup/lienzo-tests", "kiegroup/droolsjbpm-build-bootstrap"]),
+      outgoing: new Set([]),
+      depth: -1
+    },
+    "kiegroup/lienzo-tests": {
+      incoming: new Set(["kiegroup/appformer"]),
+      outgoing: new Set(["kiegroup/lienzo-core"]),
+      depth: -1
+    },
+    "kiegroup/kie-docs": {
+      incoming: new Set(),
+      outgoing: new Set(),
+      depth: -1
+    }
+  });
+});


### PR DESCRIPTION
fixes #99 

Instead of graph coloring I decided to keep track of depth of each project (much simpler).
The idea is that projects which have the same depth can be built simultaneously.

2 projects can only be built simultaneously if they don't depend on each other. Say we want to build project X and project Y. Say if X depended on Y, then X.depth > Y.depth. Similarly, if say X's dependency Z depended on Y, then X.depth > Z.depth > Y.depth. Therefore, we can safely build projects that have the same depth simultaneously.

