### PR TITLE
Add platforms section to allow specifying of different git providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ build: [build information]
 
 ### Valid versions
 
+* 2.3
 * 2.2
 * 2.1
 
@@ -62,6 +63,18 @@ and stablish their dependencies with each other
 - project: kiegroup/drools
   dependencies:
     - project: kiegroup/lienzo-tests
+```
+
+#### version 2.3 additions
+
+For each dependency you can add a field called `platform` which contains the `id` of the git platform you want to use for that project. Example:
+
+```
+dependencies:
+  - project: PROJECT_NAME
+    dependencies:
+      - project: PROJECT_NAME
+        platform: PLATFORM_ID
 ```
 
 ### Mapping
@@ -387,6 +400,21 @@ it will produce
         current: |
            rm -rf ./*
            echo 'TEST1'
+```
+
+### Platforms (only in version 2.3)
+
+You can define multiple git platforms and define which platform to use for each project. By default if no platform is defined then community GitHub is used (i.e. non-enterprise). Useful when you have some projects on GitHub enterprise, GitLab, self-hosted GitLab etc.
+
+```
+platforms:
+  - name: [OPTIONAL] Human readable name of the platform (eg: GitHub enterprise)
+  - id: Unique identifier of the platform. Used to map a platform to a project. Used in dependencies section
+  - type: The type platform. "github" or "gitlab"
+  - tokenId: [OPTIONAL] env key value in which the token will be available for use. By default it is GITHUB_TOKEN for github and GITLAB_TOKEN for gitlab
+  - serverUrl: [OPTIONAL] url from which we can clone the projects from. By default it is https://github.com for github and https://gitlab.com for gitlab
+  - apiUrl: [OPTIONAL] url through which we can access the platform's APIs. By default it is https://api.github.com for github and https://gitlab.com/api/v4
+  - 
 ```
 
 ## Development

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kie/build-chain-configuration-reader",
-  "version": "3.0.16",
+  "version": "3.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kie/build-chain-configuration-reader",
-      "version": "3.0.16",
+      "version": "3.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kie/build-chain-configuration-reader",
-  "version": "3.0.16",
+  "version": "3.1.0",
   "description": "A library to read build-chain tool configuration files",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",

--- a/src/domain/definition-file.ts
+++ b/src/domain/definition-file.ts
@@ -1,9 +1,10 @@
 import { Build, BuildCommand } from "@bc-cr/domain/build";
 import { Dependency } from "@bc-cr/domain/dependencies";
+import { Platform } from "@bc-cr/domain/platform";
 import { Post, Pre } from "@bc-cr/domain/pre-post";
 
 export interface DefinitionFile {
-  version: "2.1" | 2.1 | "2.2" | 2.2;
+  version: "2.1" | 2.1 | "2.2" | 2.2 | "2.3" | 2.3;
   dependencies?: string | Dependency[];
   extends?: string;
   default?: {
@@ -12,4 +13,5 @@ export interface DefinitionFile {
   build?: Build[];
   pre?: Pre;
   post?: Post;
+  platforms?: Platform[]
 }

--- a/src/domain/dependencies.ts
+++ b/src/domain/dependencies.ts
@@ -6,4 +6,5 @@ export interface Dependency {
     project: string;
   }[];
   mapping?: Mapping;
+  platform?: string
 }

--- a/src/domain/platform.ts
+++ b/src/domain/platform.ts
@@ -1,0 +1,17 @@
+export interface Platform {
+  name?: string;
+  id: string;
+  type: PlatformType
+  serverUrl: string,
+  apiUrl: string
+}
+
+export enum PlatformType {
+  GITHUB = "github",
+  GITLAB = "gitlab"
+}
+
+export const DEFAULT_GITHUB_SERVER_URL = "https://github.com";
+export const DEFAULT_GITHUB_API_URL = "https://api.github.com";
+export const DEFAULT_GITLAB_SERVER_URL = "https://gitlab.com";
+export const DEFAULT_GITLAB_API_URL = "https://gitlab.com/api/v4";

--- a/src/domain/platform.ts
+++ b/src/domain/platform.ts
@@ -3,7 +3,8 @@ export interface Platform {
   id: string;
   type: PlatformType
   serverUrl: string,
-  apiUrl: string
+  apiUrl: string,
+  tokenId: string,
 }
 
 export enum PlatformType {
@@ -13,5 +14,7 @@ export enum PlatformType {
 
 export const DEFAULT_GITHUB_SERVER_URL = "https://github.com";
 export const DEFAULT_GITHUB_API_URL = "https://api.github.com";
+export const DEFAULT_GITHUB_TOKEN_ID = "GITHUB_TOKEN";
 export const DEFAULT_GITLAB_SERVER_URL = "https://gitlab.com";
 export const DEFAULT_GITLAB_API_URL = "https://gitlab.com/api/v4";
+export const DEFAULT_GITLAB_TOKEN_ID = "GITLAB_TOKEN";

--- a/src/schema/definition-file.ts
+++ b/src/schema/definition-file.ts
@@ -1,12 +1,13 @@
 import { DefinitionFile } from "@bc-cr/domain/definition-file";
 import { BuildCommandSchema, BuildSchema } from "@bc-cr/schema/build";
-import { DependenciesSchema } from "@bc-cr/schema/dependencies";
+import { DefinitionFileVersionToDependencySchema, DependenciesSchema } from "@bc-cr/schema/dependencies";
+import { PlatformSchema } from "@bc-cr/schema/platform";
 import { JSONSchemaType } from "ajv";
 
 export const DefintionFileSchema: JSONSchemaType<DefinitionFile> = {
   type: "object",
   properties: {
-    version: { type: ["string", "number"], enum: ["2.1", 2.1, "2.2", 2.2] },
+    version: { type: ["string", "number"], enum: ["2.1", 2.1, "2.2", 2.2, "2.3", 2.3] },
     dependencies: {
       type: ["string", "array"],
       oneOf: [
@@ -48,6 +49,33 @@ export const DefintionFileSchema: JSONSchemaType<DefinitionFile> = {
         failure: {type: "array", items: {type: "string"}, nullable: true},
       },
       nullable: true
+    },
+    platforms: {
+      type: "array",
+      items: PlatformSchema,
+      nullable: true
+    }
+  },
+  if: {
+    properties: {
+      version: {
+        not: {
+          enum: ["2.3", 2.3]
+        }
+      }
+    }
+  },
+  then: {
+    properties: {
+      dependencies: {
+        type: ["string", "array"],
+        oneOf: [
+          { type: "string" },
+          DefinitionFileVersionToDependencySchema["2.2"],
+        ],
+        nullable: true
+      },
+      platforms: false
     }
   },
   required: ["version"],

--- a/src/schema/dependencies.ts
+++ b/src/schema/dependencies.ts
@@ -9,6 +9,10 @@ export const DependenciesSchema: JSONSchemaType<Dependency[]> = {
     type: "object",
     properties: {
       project: ProjectNameSchema,
+      platform: {
+        type: "string",
+        nullable: true
+      },
       dependencies: {
         type: "array",
         items: {
@@ -27,3 +31,21 @@ export const DependenciesSchema: JSONSchemaType<Dependency[]> = {
     additionalProperties: false,
   },
 };
+
+export const DefinitionFileVersionToDependencySchema: {
+  "2.2": JSONSchemaType<Omit<Dependency, "platform">[]>,
+  "2.3": JSONSchemaType<Dependency[]>
+} = {
+  "2.3": DependenciesSchema,
+  "2.2": {
+    ...DependenciesSchema,
+    items: {
+      ...DependenciesSchema.items,
+      properties: {
+        ...DependenciesSchema.items.properties,
+        platform: false
+      }
+    }
+  } as JSONSchemaType<Omit<Dependency, "platform">[]>
+};
+

--- a/src/schema/platform.ts
+++ b/src/schema/platform.ts
@@ -1,8 +1,10 @@
 import {
   DEFAULT_GITHUB_API_URL,
   DEFAULT_GITHUB_SERVER_URL,
+  DEFAULT_GITHUB_TOKEN_ID,
   DEFAULT_GITLAB_API_URL,
   DEFAULT_GITLAB_SERVER_URL,
+  DEFAULT_GITLAB_TOKEN_ID,
   Platform,
   PlatformType,
 } from "@bc-cr/domain/platform";
@@ -28,8 +30,11 @@ export const PlatformSchema: JSONSchemaType<Platform> = {
     apiUrl: {
       type: "string",
     },
+    tokenId: {
+      type: "string"
+    }
   },
-  required: ["apiUrl", "id", "type", "serverUrl"],
+  required: ["apiUrl", "id", "type", "serverUrl", "tokenId"],
   if: {
     properties: {
       type: {
@@ -45,6 +50,9 @@ export const PlatformSchema: JSONSchemaType<Platform> = {
       serverUrl: {
         default: DEFAULT_GITHUB_SERVER_URL,
       },
+      tokenId: {
+        default: DEFAULT_GITHUB_TOKEN_ID
+      }
     },
   },
   else: {
@@ -55,6 +63,9 @@ export const PlatformSchema: JSONSchemaType<Platform> = {
       serverUrl: {
         default: DEFAULT_GITLAB_SERVER_URL,
       },
+      tokenId: {
+        default: DEFAULT_GITLAB_TOKEN_ID
+      }
     },
   },
 };

--- a/src/schema/platform.ts
+++ b/src/schema/platform.ts
@@ -1,0 +1,60 @@
+import {
+  DEFAULT_GITHUB_API_URL,
+  DEFAULT_GITHUB_SERVER_URL,
+  DEFAULT_GITLAB_API_URL,
+  DEFAULT_GITLAB_SERVER_URL,
+  Platform,
+  PlatformType,
+} from "@bc-cr/domain/platform";
+import { JSONSchemaType } from "ajv";
+
+export const PlatformSchema: JSONSchemaType<Platform> = {
+  type: "object",
+  properties: {
+    name: {
+      type: "string",
+      nullable: true,
+    },
+    id: {
+      type: "string",
+    },
+    serverUrl: {
+      type: "string",
+    },
+    type: {
+      type: "string",
+      enum: [PlatformType.GITHUB, PlatformType.GITLAB],
+    },
+    apiUrl: {
+      type: "string",
+    },
+  },
+  required: ["apiUrl", "id", "type", "serverUrl"],
+  if: {
+    properties: {
+      type: {
+        enum: [PlatformType.GITHUB],
+      },
+    },
+  },
+  then: {
+    properties: {
+      apiUrl: {
+        default: DEFAULT_GITHUB_API_URL,
+      },
+      serverUrl: {
+        default: DEFAULT_GITHUB_SERVER_URL,
+      },
+    },
+  },
+  else: {
+    properties: {
+      apiUrl: {
+        default: DEFAULT_GITLAB_API_URL,
+      },
+      serverUrl: {
+        default: DEFAULT_GITLAB_SERVER_URL,
+      },
+    },
+  },
+};

--- a/test/util/yaml.test.ts
+++ b/test/util/yaml.test.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_GITHUB_API_URL, DEFAULT_GITHUB_SERVER_URL, DEFAULT_GITLAB_API_URL, DEFAULT_GITLAB_SERVER_URL } from "@bc-cr/domain/platform";
+import { DEFAULT_GITHUB_API_URL, DEFAULT_GITHUB_SERVER_URL, DEFAULT_GITHUB_TOKEN_ID, DEFAULT_GITLAB_API_URL, DEFAULT_GITLAB_SERVER_URL, DEFAULT_GITLAB_TOKEN_ID } from "@bc-cr/domain/platform";
 import { validateDefinitionFile } from "@bc-cr/util/yaml";
 import { readdirSync, readFileSync } from "fs";
 import path from "path";
@@ -494,7 +494,8 @@ describe("schema 2.3", () => {
           id: "ghes",
           type: "github",
           serverUrl: "https://ghes.com",
-          apiUrl: "https://api.ghes.com"
+          apiUrl: "https://api.ghes.com",
+          tokenId: "GHES_TOKEN"
         }
       ]
     };
@@ -510,20 +511,23 @@ describe("schema 2.3", () => {
           id: "gh",
           type: "github",
           serverUrl: DEFAULT_GITHUB_SERVER_URL,
-          apiUrl: DEFAULT_GITHUB_API_URL
+          apiUrl: DEFAULT_GITHUB_API_URL,
+          tokenId: DEFAULT_GITHUB_TOKEN_ID
         },
         {
           name: "private gitlab",
           id: "gl",
           type: "gitlab",
           serverUrl: DEFAULT_GITLAB_SERVER_URL,
-          apiUrl: DEFAULT_GITLAB_API_URL
+          apiUrl: DEFAULT_GITLAB_API_URL,
+          tokenId: DEFAULT_GITLAB_TOKEN_ID
         },
         {
           id: "ghes",
           type: "github",
           serverUrl: "https://ghes.com",
-          apiUrl: "https://api.ghes.com"
+          apiUrl: "https://api.ghes.com",
+          tokenId: "GHES_TOKEN"
         }
       ]
     });


### PR DESCRIPTION
Part of https://github.com/kiegroup/github-action-build-chain/issues/320

The domain object for Platforms is defined as 
```typescript
interface Platform {
  name?: string;
  id: string;
  type: PlatformType
  serverUrl: string,
  apiUrl: string,
  tokenId: string,
}
```

Note that although in the domain object only `name` looks optional, in reality when user defining the platform section in definition file only id and type are mandatory. The rest have a default value (explained in the README.md) which is added during yaml validation.

I also made some changes to the discussed fields:
- new `id` field. The `id` field will help us map the dependencies to a platform. The `name` field is to make the identification of the platform more human readable. So for example if I were to define a GitHub Enterprise platform then for `id` i would pass `ghes` and for `name` I would pass GitHub Enterprise
- Using `tokenId` instead of `token`. Sometimes `token` field is used to pass the actual token. To avoid this confusion I picked `tokenId` so that it indicates that you need to pass some sort of an identifier for the token you want to use and not the actual token.
- Instead of `api-version`, we have `serverUrl` and `apiUrl`. The `api-version` field might not be valid for GitHub. Defining to separate URL also makes the platform section more generic as it opens up for GitHub Enterprise users. The `serverUrl` is where we can clone the repositories from. This also opens it up to allow ssh clones.

Finally, the `platforms` field and the `platform` field inside the dependencies section are only available in definition file version `2.3`. I have added yaml validations to ensure this

