### PR TITLE
fix: make platformId optional in node object

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kie/build-chain-configuration-reader",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kie/build-chain-configuration-reader",
-      "version": "3.1.2",
+      "version": "3.1.3",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kie/build-chain-configuration-reader",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "A library to read build-chain tool configuration files",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",

--- a/src/domain/node.ts
+++ b/src/domain/node.ts
@@ -13,5 +13,5 @@ export interface Node {
   mapping?: Mapping;
   clone?: string[];
   archiveArtifacts?: ArchiveArtifacts;
-  platformId: string
+  platformId?: string
 }

--- a/src/util/construct-node.ts
+++ b/src/util/construct-node.ts
@@ -1,7 +1,6 @@
 import { Build, BuildCommand, CommandLevel } from "@bc-cr/domain/build";
 import { Dependency } from "@bc-cr/domain/dependencies";
 import { Node } from "@bc-cr/domain/node";
-import { DEFAULT_GITHUB_PLATFORM } from "@bc-cr/domain/platform";
 
 export function constructNode(
   dependency: Dependency,
@@ -27,7 +26,7 @@ export function constructNode(
       current: buildCommand?.current ?? [],
     },
     ...(clone ? { clone } : {}),
-    platformId: dependency.platform ?? DEFAULT_GITHUB_PLATFORM.id
+    platformId: dependency.platform
   };
 }
 


### PR DESCRIPTION
Need to keep platformId optional in node object since the default platform can be either github or gitlab i.e. it doesn't necessarily have to be github and will depend on build-chain execution